### PR TITLE
Remove custom version injection because it does not work well due to multi-module build

### DIFF
--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -80,10 +80,6 @@ fi
 RELEASE="${RELEASE}.${BUILD_NUMBER}"
 FULL_BUILD_VERSION="${HBASE_VERSION}-${RELEASE}"
 
-# Add into MAVEN_ARGS because we added this property in hbase-common/pom.xml so we 
-# could accurately reflect the full build version in the UI and elsewhere.
-MAVEN_ARGS="$MAVEN_ARGS -Dhubspot.build.version=$FULL_BUILD_VERSION"
-
 #
 # Dump generated env vars into rc file
 #

--- a/hbase-common/pom.xml
+++ b/hbase-common/pom.xml
@@ -31,10 +31,6 @@
   <name>Apache HBase - Common</name>
   <description>Common functionality for HBase</description>
 
-  <properties>
-    <hubspot.build.version>${project.version}</hubspot.build.version>
-  </properties>
-
   <build>
     <resources>
       <resource>
@@ -80,7 +76,7 @@
             <configuration>
               <target>
                 <replace file="${project.build.outputDirectory}/hbase-default.xml"
-                  token="@@@VERSION@@@" value="${hubspot.build.version}" />
+                  token="@@@VERSION@@@" value="${project.version}" />
               </target>
             </configuration>
             <goals>
@@ -96,7 +92,7 @@
                             <property name="generated.sources" location="${project.build.directory}/generated-sources"/>
 
                             <exec executable="bash" failonerror="true">
-                                <arg line="${basedir}/src/saveVersion.sh ${hubspot.build.version} ${generated.sources}/java"/>
+                                <arg line="${basedir}/src/saveVersion.sh ${project.version} ${generated.sources}/java"/>
                             </exec>
                         </target>
                     </configuration>


### PR DESCRIPTION
I added this when I initially set up the hubspot build, thinking it'd be nice to reflect our actual build numbers in the various UIs, logs, etc. Unfortunately it doesn't work as well as I'd hope, because of the fact that we use multi-module build. The Version class is written by `hbase-common` module, which may not get built for every merged change. For example, if a change is pushed to `hbase-server`, that will not result in a re-build of `hbase-common`. So the Version will not update and this can be misleading.

There are other options we could consider for injecting our own version, but for now I'm just going to remove this so that we revert to the default behavior of just having it be the upstream version (i.e. just 2.4.6 instead of 2.4.6-hs.35)

Related to HBasePlanning#764