### PR TITLE
Add back custom version injection, but set it to the raw HBASE_VERSION

### DIFF
--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -80,6 +80,10 @@ fi
 RELEASE="${RELEASE}.${BUILD_NUMBER}"
 FULL_BUILD_VERSION="${HBASE_VERSION}-${RELEASE}"
 
+# Add into MAVEN_ARGS because we added this property in hbase-common/pom.xml so we 
+# could accurately reflect the full build version in the UI and elsewhere.
+MAVEN_ARGS="$MAVEN_ARGS -Dhubspot.build.version=$HBASE_VERSION"
+
 #
 # Dump generated env vars into rc file
 #

--- a/hbase-common/pom.xml
+++ b/hbase-common/pom.xml
@@ -31,6 +31,10 @@
   <name>Apache HBase - Common</name>
   <description>Common functionality for HBase</description>
 
+  <properties>
+    <hubspot.build.version>${project.version}</hubspot.build.version>
+  </properties>
+
   <build>
     <resources>
       <resource>
@@ -76,7 +80,7 @@
             <configuration>
               <target>
                 <replace file="${project.build.outputDirectory}/hbase-default.xml"
-                  token="@@@VERSION@@@" value="${project.version}" />
+                  token="@@@VERSION@@@" value="${hubspot.build.version}" />
               </target>
             </configuration>
             <goals>
@@ -92,7 +96,7 @@
                             <property name="generated.sources" location="${project.build.directory}/generated-sources"/>
 
                             <exec executable="bash" failonerror="true">
-                                <arg line="${basedir}/src/saveVersion.sh ${project.version} ${generated.sources}/java"/>
+                                <arg line="${basedir}/src/saveVersion.sh ${hubspot.build.version} ${generated.sources}/java"/>
                             </exec>
                         </target>
                     </configuration>


### PR DESCRIPTION
This reverts commit f556810b52bb6dfb27518c3b16951887ff71f920 (#2).

I realized that because of how our build works, we actually set the maven version to `2.0-hubspot-SNAPSHOT`. This is mostly for the benefit of clients, where we expect to use snapshots. Unfortunately it also means that the VersionInfo gets set to that same value, which is not as useful. I've added back the injection, but I make sure to simply set it to the current hbase version, i.e. 2.4.6.