### PR TITLE
HBASE-26745 Include Balancer Cost metrics in jmx endpoint

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/util/JSONBean.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/util/JSONBean.java
@@ -255,7 +255,7 @@ public class JSONBean {
     if ("modelerType".equals(attName)) {
       return;
     }
-    if (attName.indexOf("=") >= 0 || attName.indexOf(":") >= 0 || attName.indexOf(" ") >= 0) {
+    if (attName.indexOf("=") >= 0 || attName.indexOf(" ") >= 0) {
       return;
     }
 

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/util/TestJSONBean.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/util/TestJSONBean.java
@@ -59,7 +59,7 @@ public class TestJSONBean {
     MBeanInfo mbeanInfo = mock(MBeanInfo.class);
     when(mbeanInfo.getClassName()).thenReturn("testClassName");
     String[] attributeNames = new String[] {"intAttr", "nanAttr", "infinityAttr",
-      "strAttr", "boolAttr"};
+      "strAttr", "boolAttr", "test:Attr"};
     MBeanAttributeInfo[] attributeInfos = new MBeanAttributeInfo[attributeNames.length];
     for (int i = 0; i < attributeInfos.length; i++) {
       attributeInfos[i] = new MBeanAttributeInfo(attributeNames[i],
@@ -77,6 +77,7 @@ public class TestJSONBean {
       thenReturn(Double.POSITIVE_INFINITY);
     when(mbeanServer.getAttribute(any(), eq("strAttr"))).thenReturn("aString");
     when(mbeanServer.getAttribute(any(), eq("boolAttr"))).thenReturn(true);
+    when(mbeanServer.getAttribute(any(), eq("test:Attr"))).thenReturn("aString");
     return mbeanServer;
   }
 
@@ -92,7 +93,8 @@ public class TestJSONBean {
     pw.println("      \"nanAttr\": \"NaN\",");
     pw.println("      \"infinityAttr\": \"Infinity\",");
     pw.println("      \"strAttr\": \"aString\",");
-    pw.println("      \"boolAttr\": true");
+    pw.println("      \"boolAttr\": true,");
+    pw.println("      \"test:Attr\": aString");
     pw.println("    }");
     pw.println("  ]");
     pw.print("}");


### PR DESCRIPTION
Enable the balancer cost metrics to be included in the `/jmx` endpoint. This should be backwards compatible and has been deployed in our cdh5 fork for over a year. 