### PR TITLE
Give hbase-assembly a name in Blazar

### DIFF
--- a/hbase-assembly/.blazar.yaml
+++ b/hbase-assembly/.blazar.yaml
@@ -4,6 +4,9 @@ buildpack:
   repository: Blazar-Buildpack-Java
   branch: v2
 
+provides:
+  - name: hbase-rpm
+
 env:
   RPMS_OUTPUT_DIR: "$WORKSPACE/generated_rpms"
   MAVEN_PHASE: package assembly:single


### PR DESCRIPTION
Giving this module a name in Blazar will allow us to automatically trigger downstream Docker image builds