### PR TITLE
HBASE 26798 improve balancer visibility

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -560,6 +560,8 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
       sendRegionPlansToRingBuffer(plans, currentCost, initCost, initFunctionTotalCosts, step);
       return plans;
     }
+
+    //// TODO(baugenreich) how to add in move cost/general logs without overwhelming the logs
     LOG.info("Could not find a better moving plan.  Tried {} different configurations in "
         + "{} ms, and did not find anything with an imbalance score less than {}.", step,
       endTime - startTime, initCost / sumMultiplier);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -533,6 +533,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
         curOverallCost = currentCost;
         System.arraycopy(tempFunctionCosts, 0, curFunctionCosts, 0, curFunctionCosts.length);
       } else {
+        // // TODO(baugenreich) move cost logs could go here but again seems like it would be printed too often
         // Put things back the way they were before.
         // TODO: undo by remembering old values
         Action undoAction = action.undoAction();
@@ -794,7 +795,6 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
       if (!c.isNeeded()) {
         continue;
       }
-
       Float multiplier = c.getMultiplier();
       double cost = c.cost();
 
@@ -974,10 +974,13 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
       // Don't let this single balance move more than the max moves.
       // This allows better scaling to accurately represent the actual cost of a move.
       if (moveCost > maxMoves) {
+        LOG.info("Calculated moves exceed maxMoves {}. Greatly increasing move cost. ", maxMoves); //// TODO(baugenreich) is this helpful?
         return 1000000;   // return a number much greater than any of the other cost
       }
+      double scaledMoveCost = scale(0, Math.min(cluster.numRegions, maxMoves), moveCost);
 
-      return scale(0, Math.min(cluster.numRegions, maxMoves), moveCost);
+      //// TODO(baugenreich) Im tempted to log the movecost here but then it will be logged for every calculated plan which seems like a lot.
+      return scaledMoveCost;
     }
   }
 


### PR DESCRIPTION
Improve our ability to understand how and why the balancer is/isnt balancing:
1. Report the metrics shared in log output
2. Add the metrics reported to the log statements 
3. Additional logging to report when the move cost is greatly impacting the ability for the balancer to take action 