### PR TITLE
Fix client bundle metrics dep issues

### DIFF
--- a/hubspot-client-bundles/hbase-client-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-client-bundle/pom.xml
@@ -85,6 +85,9 @@
                   <include>org.apache.hbase:hbase-endpoint</include>
 
                   <include>com.google.protobuf:protobuf-java</include>
+
+                  <!--  For client metrics we need to include so the metrics package can be shaded to prevent issues with our parent pom -->
+                  <include>io.dropwizard.metrics:metrics-core</include>
                 </includes>
               </artifactSet>
               <filters>

--- a/hubspot-client-bundles/pom.xml
+++ b/hubspot-client-bundles/pom.xml
@@ -74,6 +74,10 @@
                     <pattern>com.google.protobuf</pattern>
                     <shadedPattern>${shade.prefix}.com.google.protobuf</shadedPattern>
                   </relocation>
+                  <relocation>
+                    <pattern>com.codahale.metrics</pattern>
+                    <shadedPattern>${shade.prefix}.com.codahale.metrics</shadedPattern>
+                  </relocation>
                   <!-- 
                     This is a little brittle, but as far as I can tell this class list hasn't
                     really changed much. The core problem this solves is that our hadoop jobs


### PR DESCRIPTION
Update the hb2 client bundle to include + relocate the dropwizard metrics. The version hubspot enforces is not backwards compatible with the version hbase expects. 