### PR TITLE
Replica fallbacks

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Query.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Query.java
@@ -159,7 +159,7 @@ public abstract class Query extends OperationWithAttributes {
    * as the data source on primary timeout. Enabling this funnels calls to a single replica, rather than submitting
    * calls to all the secondaries at once
    * <br><b> Expert: </b>This is an advanced API exposed. Only use it if you know what you are doing
-   * @param Id
+   * @param isFallback
    */
   public Query setReplicaIdIsFallback(boolean isFallback) {
     this.isReplicaIdFallback = isFallback;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Query.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Query.java
@@ -18,9 +18,6 @@
 package org.apache.hadoop.hbase.client;
 
 import java.util.Map;
-
-import org.apache.hbase.thirdparty.com.google.common.collect.Maps;
-import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hadoop.hbase.exceptions.DeserializationException;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.io.TimeRange;
@@ -29,11 +26,12 @@ import org.apache.hadoop.hbase.security.access.AccessControlUtil;
 import org.apache.hadoop.hbase.security.access.Permission;
 import org.apache.hadoop.hbase.security.visibility.Authorizations;
 import org.apache.hadoop.hbase.security.visibility.VisibilityConstants;
-import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
-
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hbase.thirdparty.com.google.common.collect.ArrayListMultimap;
 import org.apache.hbase.thirdparty.com.google.common.collect.ListMultimap;
-import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hbase.thirdparty.com.google.common.collect.Maps;
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 
 /**
  * Base class for HBase read operations; e.g. Scan and Get.
@@ -43,6 +41,7 @@ public abstract class Query extends OperationWithAttributes {
   private static final String ISOLATION_LEVEL = "_isolationlevel_";
   protected Filter filter = null;
   protected int targetReplicaId = -1;
+  protected int fallbackReplicaId = -1;
   protected Consistency consistency = Consistency.STRONG;
   protected Map<byte[], TimeRange> colFamTimeRangeMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
   protected Boolean loadColumnFamiliesOnDemand = null;
@@ -150,6 +149,26 @@ public abstract class Query extends OperationWithAttributes {
    */
   public int getReplicaId() {
     return this.targetReplicaId;
+  }
+
+  /**
+   * Specify region replica id where Query will fetch data from if a call to the primary, fails
+   * Use this together with {@link #setConsistency(Consistency)} passing {@link Consistency#TIMELINE}
+   * to read data from a specific replicaId. Will no-op if {@link #setReplicaId(int)} is set
+   * <br><b> Expert: </b>This is an advanced API exposed. Only use it if you know what you are doing
+   * @param Id
+   */
+  public Query setFallbackReplicaId(int Id) {
+    this.fallbackReplicaId = Id;
+    return this;
+  }
+
+  /**
+   * Returns region replica id where Query will fetch data from if the primary doesn't succeed.
+   * @return region fallback replica id or -1 if not set.
+   */
+  public int getFallbackReplicaId() {
+    return fallbackReplicaId;
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Query.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Query.java
@@ -43,7 +43,7 @@ public abstract class Query extends OperationWithAttributes {
   private static final String ISOLATION_LEVEL = "_isolationlevel_";
   protected Filter filter = null;
   protected int targetReplicaId = -1;
-  protected int fallbackReplicaId = -1;
+  protected boolean isReplicaIdFallback = false;
   protected Consistency consistency = Consistency.STRONG;
   protected Map<byte[], TimeRange> colFamTimeRangeMap = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
   protected Boolean loadColumnFamiliesOnDemand = null;
@@ -154,23 +154,23 @@ public abstract class Query extends OperationWithAttributes {
   }
 
   /**
-   * Specify region replica id where Query will fetch data from if a call to the primary, fails
-   * Use this together with {@link #setConsistency(Consistency)} passing {@link Consistency#TIMELINE}
-   * to read data from a specific replicaId. Will no-op if {@link #setReplicaId(int)} is set
+   * Specify whether the replica should be used as a fallback option, or the immediate query data source
+   * If true, the query will attempt to fetch data from the primary, and fallback to the {@link #getReplicaId()}
+   * as the data source on primary timeout. Enabling this funnels calls to a single replica, rather than submitting
+   * calls to all the secondaries at once
    * <br><b> Expert: </b>This is an advanced API exposed. Only use it if you know what you are doing
    * @param Id
    */
-  public Query setFallbackReplicaId(int Id) {
-    this.fallbackReplicaId = Id;
+  public Query setReplicaIdIsFallback(boolean isFallback) {
+    this.isReplicaIdFallback = isFallback;
     return this;
   }
 
   /**
-   * Returns region replica id where Query will fetch data from if the primary doesn't succeed.
-   * @return region fallback replica id or -1 if not set.
+   * Returns whether the {@link #getReplicaId()} should be used as a fallback
    */
-  public int getFallbackReplicaId() {
-    return fallbackReplicaId;
+  public boolean isReplicaIdFallback() {
+    return isReplicaIdFallback;
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Query.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Query.java
@@ -18,6 +18,9 @@
 package org.apache.hadoop.hbase.client;
 
 import java.util.Map;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.Maps;
+import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hadoop.hbase.exceptions.DeserializationException;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.io.TimeRange;
@@ -26,12 +29,11 @@ import org.apache.hadoop.hbase.security.access.AccessControlUtil;
 import org.apache.hadoop.hbase.security.access.Permission;
 import org.apache.hadoop.hbase.security.visibility.Authorizations;
 import org.apache.hadoop.hbase.security.visibility.VisibilityConstants;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+
 import org.apache.hbase.thirdparty.com.google.common.collect.ArrayListMultimap;
 import org.apache.hbase.thirdparty.com.google.common.collect.ListMultimap;
-import org.apache.hbase.thirdparty.com.google.common.collect.Maps;
-import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.util.Bytes;
 
 /**
  * Base class for HBase read operations; e.g. Scan and Get.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RpcRetryingCallerWithReadReplicas.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RpcRetryingCallerWithReadReplicas.java
@@ -169,8 +169,6 @@ public class RpcRetryingCallerWithReadReplicas {
   public Result call(int operationTimeout)
       throws DoNotRetryIOException, InterruptedIOException, RetriesExhaustedException {
     boolean isTargetReplicaSpecified = (get.getReplicaId() >= 0);
-    boolean fallbackExists = get.getFallbackReplicaId() != get.getReplicaId()
-      && get.getFallbackReplicaId() > 0;
 
     RegionLocations rl = null;
     boolean skipPrimary = false;
@@ -206,7 +204,7 @@ public class RpcRetryingCallerWithReadReplicas {
     int startIndex = 0;
     int endIndex = rl.size();
 
-    if(isTargetReplicaSpecified) {
+    if(isTargetReplicaSpecified && !get.isReplicaIdFallback()) {
       addCallsForReplica(cs, rl, get.getReplicaId(), get.getReplicaId());
       endIndex = 1;
     } else {
@@ -239,8 +237,8 @@ public class RpcRetryingCallerWithReadReplicas {
         endIndex --;
       }
 
-      if (fallbackExists) {
-        addCallsForReplica(cs, rl, get.getFallbackReplicaId(), get.getFallbackReplicaId());
+      if (isTargetReplicaSpecified && get.isReplicaIdFallback()) {
+        addCallsForReplica(cs, rl, get.getReplicaId(), get.getReplicaId());
       } else {
         // submit call for the all of the secondaries at once
         addCallsForReplica(cs, rl, 1, rl.size() - 1);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ScannerCallableWithReplicas.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ScannerCallableWithReplicas.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HRegionInfo;
@@ -231,8 +230,12 @@ class ScannerCallableWithReplicas implements RetryingCallable<Result[]> {
       // the secondaries
       endIndex = 1;
     } else {
-      // TODO: this may be an overkill for large region replication
-      addCallsForOtherReplicas(cs, 0, regionReplication - 1);
+      if (scan.getFallbackReplicaId() != scan.getReplicaId() && scan.getFallbackReplicaId() > 0) {
+        addCallsForOtherReplicas(cs, scan.getFallbackReplicaId(), scan.getFallbackReplicaId());
+      } else {
+        // TODO: this may be an overkill for large region replication
+        addCallsForOtherReplicas(cs, 0, regionReplication - 1);
+      }
     }
 
     try {


### PR DESCRIPTION
### Goal

Currently, reading from HBase with a `TIMELINE` consistency follows one of two paths

1. The `Query#replicaId` isn't set. Attempt to fetch data from the primary, and if that hits a timeout `hbase.client.primaryCallTimeout.get/multiget` or `hbase.client.replicaCallTimeout.scan`, then attempt the same data fetch operation on _all_ the secondary replicas. 
2. The `Query#replicaId` is set. Read directly from the replica specified, without any sort of fallback. Note, if the `replicaId` set is <= 0, follow data fetch path 1.

This is a bit limiting, as it prevents us from attempting to hit the primary, and falling back to specific secondary replica if the primary call times out. I think this functionality is useful for a variety of reasons. For starters, it reduces the number of RPC calls. Secondly, it allows callers to add more sophisticated query logic, such as round robin load balancing, balancing based on replica load, balancing based on replication lag, etc... It would also allow us to have a "timeline consistent" where callers would hit the same replica to avoid any out-of-order data issues. 

### Changes

This PR adds an `isReplicaIdFallback` flag. If this flag is off, then the current HBase behavior is retained. If the flag is turned on, and a `replicaId` is set, then we will still always try first fetch the data from the primary replica. If the operation times out, we fallback to a specific replica, rather than all replicas. We trade off some availability in favor of consistency.