### PR TITLE
Intra-cluster replication sink metrics

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -2218,7 +2218,6 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
   @QosPriority(priority = HConstants.REPLAY_QOS)
   public ReplicateWALEntryResponse replay(final RpcController controller,
       final ReplicateWALEntryRequest request) throws ServiceException {
-    LOG.info("We are replaying " + request.getEntryList().size() + " stuff right here");
     long before = EnvironmentEdgeManager.currentTime();
     CellScanner cells = ((HBaseRpcController) controller).cellScanner();
     try {
@@ -2281,6 +2280,9 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
               throw new IOException(result[i].getExceptionMsg());
             }
           }
+          long ageLastAppliedOp = entries.get(entries.size() -1).getKey().getWriteTime();
+          LOG.info("Setting ageLastAppliedOp to " + ageLastAppliedOp);
+          metricsSink.setAgeOfLastAppliedOp(ageLastAppliedOp);
         }
       }
 
@@ -2296,9 +2298,6 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
             entry.getSecond());
         }
       }
-      long ageLastAppliedOp = entries.get(entries.size() -1).getKey().getWriteTime();
-      LOG.info("Setting ageLastAppliedOp to " + ageLastAppliedOp);
-      metricsSink.setAgeOfLastAppliedOp(ageLastAppliedOp);
       return ReplicateWALEntryResponse.newBuilder().build();
     } catch (IOException ie) {
       throw new ServiceException(ie);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -156,7 +156,6 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hbase.thirdparty.com.google.common.cache.Cache;
 import org.apache.hbase.thirdparty.com.google.common.cache.CacheBuilder;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
@@ -167,7 +166,6 @@ import org.apache.hbase.thirdparty.com.google.protobuf.ServiceException;
 import org.apache.hbase.thirdparty.com.google.protobuf.TextFormat;
 import org.apache.hbase.thirdparty.com.google.protobuf.UnsafeByteOperations;
 import org.apache.hbase.thirdparty.org.apache.commons.collections4.CollectionUtils;
-
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.RequestConverter;
 import org.apache.hadoop.hbase.shaded.protobuf.ResponseConverter;
@@ -2220,6 +2218,7 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
   @QosPriority(priority = HConstants.REPLAY_QOS)
   public ReplicateWALEntryResponse replay(final RpcController controller,
       final ReplicateWALEntryRequest request) throws ServiceException {
+    LOG.info("We are replaying " + request.getEntryList().size() + " stuff right here");
     long before = EnvironmentEdgeManager.currentTime();
     CellScanner cells = ((HBaseRpcController) controller).cellScanner();
     try {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -134,6 +134,7 @@ import org.apache.hadoop.hbase.regionserver.handler.OpenMetaHandler;
 import org.apache.hadoop.hbase.regionserver.handler.OpenPriorityRegionHandler;
 import org.apache.hadoop.hbase.regionserver.handler.OpenRegionHandler;
 import org.apache.hadoop.hbase.regionserver.handler.UnassignRegionHandler;
+import org.apache.hadoop.hbase.replication.regionserver.MetricsSink;
 import org.apache.hadoop.hbase.security.Superusers;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.access.AccessChecker;
@@ -322,6 +323,8 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
 
   // Request counter for rpc mutate
   final LongAdder rpcMutateRequestCount = new LongAdder();
+
+  private final MetricsSink metricsSink = new MetricsSink();
 
   // Server to handle client requests.
   final RpcServerInterface rpcServer;
@@ -2294,6 +2297,9 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
             entry.getSecond());
         }
       }
+      long ageLastAppliedOp = entries.get(entries.size() -1).getKey().getWriteTime();
+      LOG.info("Setting ageLastAppliedOp to " + ageLastAppliedOp);
+      metricsSink.setAgeOfLastAppliedOp(ageLastAppliedOp);
       return ReplicateWALEntryResponse.newBuilder().build();
     } catch (IOException ie) {
       throw new ServiceException(ie);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -155,6 +155,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.apache.hbase.thirdparty.com.google.common.cache.Cache;
 import org.apache.hbase.thirdparty.com.google.common.cache.CacheBuilder;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
@@ -165,6 +166,7 @@ import org.apache.hbase.thirdparty.com.google.protobuf.ServiceException;
 import org.apache.hbase.thirdparty.com.google.protobuf.TextFormat;
 import org.apache.hbase.thirdparty.com.google.protobuf.UnsafeByteOperations;
 import org.apache.hbase.thirdparty.org.apache.commons.collections4.CollectionUtils;
+
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.RequestConverter;
 import org.apache.hadoop.hbase.shaded.protobuf.ResponseConverter;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -134,7 +134,6 @@ import org.apache.hadoop.hbase.regionserver.handler.OpenMetaHandler;
 import org.apache.hadoop.hbase.regionserver.handler.OpenPriorityRegionHandler;
 import org.apache.hadoop.hbase.regionserver.handler.OpenRegionHandler;
 import org.apache.hadoop.hbase.regionserver.handler.UnassignRegionHandler;
-import org.apache.hadoop.hbase.replication.regionserver.MetricsSink;
 import org.apache.hadoop.hbase.security.Superusers;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.access.AccessChecker;
@@ -321,8 +320,6 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
 
   // Request counter for rpc mutate
   final LongAdder rpcMutateRequestCount = new LongAdder();
-
-  private final MetricsSink metricsSink = new MetricsSink();
 
   // Server to handle client requests.
   final RpcServerInterface rpcServer;
@@ -2280,9 +2277,6 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
               throw new IOException(result[i].getExceptionMsg());
             }
           }
-          long ageLastAppliedOp = entries.get(entries.size() -1).getKey().getWriteTime();
-          LOG.info("Setting ageLastAppliedOp to " + ageLastAppliedOp);
-          metricsSink.setAgeOfLastAppliedOp(ageLastAppliedOp);
         }
       }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RegionReplicaReplicationEndpoint.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RegionReplicaReplicationEndpoint.java
@@ -635,7 +635,6 @@ public class RegionReplicaReplicationEndpoint extends HBaseReplicationEndpoint {
         controller.setCellScanner(p.getSecond());
         ReplicateWALEntryResponse response = stub.replay(controller, p.getFirst());
         long ageLastAppliedOp = entriesArray[entriesArray.length -1].getKey().getWriteTime();
-        LOG.info("Setting ageLastAppliedOp to " + ageLastAppliedOp);
         metricsSink.setAgeOfLastAppliedOp(ageLastAppliedOp);
         return response;
       }


### PR DESCRIPTION
#### Goal

Adds read replication sink metrics for intra-cluster replication so we can more accurately track replication lag between primary and secondary replicas. 

#### Context

Inter-cluster and intra-cluster replication is [handled differently by the server](https://hubspot.slack.com/archives/C039G5PU4AY/p1662061088447399). Replication sink metrics are _not_ currently recorded for region replication, which makes it tricky to track replication lag. I think it makes sense to add them here. 

There's a bit of weirdness here that I think is potentially OK to overlook. Replication source metrics are tracked on a per-peer basis. However, replication sink metrics are all aggregated across peers. With this PR, we'll combine inter-cluster and intra-cluster replication sink metrics. This might be okay because we're maintaining the precedence of aggregating sink metrics across peers. I'm happy to re-work this if it isn't acceptable. 

#### Testing

I've deployed these changes to `rr-test-hb2-a-qa` on tes2 and saw `ageOfLastAppliedOp` populate the chart. I wasn't sure if there was a good way to write some unit tests for this. These metrics weren't showing prior to the branch deploy while running the same load test.

![Screen Shot 2022-09-07 at 5 09 15 PM](https://user-images.githubusercontent.com/22687991/188980411-a2d22266-1edb-45ca-8a4f-96ccf521f352.png)

cc @rmdmattingly


