### PR TITLE
Add protobufs from hbase-endpoint

### DIFF
--- a/hubspot-client-bundles/hbase-client-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-client-bundle/pom.xml
@@ -95,6 +95,7 @@
                   <artifact>org.apache.hbase:hbase-endpoint</artifact>
                   <includes>
                     <include>org/apache/hadoop/hbase/client/coprocessor/**</include>
+                    <include>org/apache/hadoop/hbase/protobuf/generated/**</include>
                   </includes>
                 </filter>
                 <filter>


### PR DESCRIPTION
AggregationClient can't work without the protos. These should have been included in #12 