### PR TITLE
remove http server from exclusions 

### DIFF
--- a/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
@@ -55,10 +55,6 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.hbase</groupId>
-          <artifactId>hbase-http</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>javax.servlet.jsp</groupId>
           <artifactId>*</artifactId>
         </exclusion>


### PR DESCRIPTION
The HTTP module is required by `TableMapReduceUtil` [addHBaseDependencies](https://github.com/HubSpot/hbase/blob/hubspot-2/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java#L811) 