### PR TITLE
Temporary fix: Clone scan to avoid modifying user object from scan internals

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HTable.java
@@ -301,6 +301,10 @@ public class HTable implements Table {
    */
   @Override
   public ResultScanner getScanner(Scan scan) throws IOException {
+    // Clone to avoid modifying user object from scan internals.
+    // See https://issues.apache.org/jira/browse/HBASE-27402.
+    scan = new Scan(scan);
+
     if (scan.getCaching() <= 0) {
       scan.setCaching(scannerCaching);
     }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HBASE-27402

This caused some issues for sharded scans, because we pass the same Scan object into multiple getScanner calls for different tables. We interleave the results, which causes the Scan's mvcc value to be incorrect between each table call.

I'm providing a quick fix for us here because I'm unsure if there will be pushback on the above jira. We have lots of Table wrappers and I'm concerned about missing one if I make the change in our own HBaseUtils.