### PR TITLE
Backport HBASE-25166: MobFileCompactionChore is closing the master's shared cluster connection

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFileCompactionChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFileCompactionChore.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.CompactionState;
-import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableState;
@@ -81,8 +80,7 @@ public class MobFileCompactionChore extends ScheduledChore {
 
     boolean reported = false;
 
-    try (Connection conn = master.getConnection(); Admin admin = conn.getAdmin();) {
-
+    try (Admin admin = master.getConnection().getAdmin()) {
       TableDescriptors htds = master.getTableDescriptors();
       Map<String, TableDescriptor> map = htds.getAll();
       for (TableDescriptor htd : map.values()) {


### PR DESCRIPTION
We need this fix urgently because HMasters are failing regularly as a result of this closed connection.

Co-authored-by: Ankit Singhal <ankit@apache.org>
Signed-off-by: Xiaolin Ha <haxiaolin@apache.org>
(cherry picked from commit 66873ca5a6e76f757c2e3ea988047860b38f010b)