### PR TITLE
fix flaky test testClone in TestTaskMonitor

### DIFF
--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -367,6 +367,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- For JspC used in ant task, then needed at compile /runtime
            because the source code made from the JSP refers to its runtime
         -->

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 @Category({MiscTests.class, SmallTests.class})
 public class TestTaskMonitor {
@@ -245,7 +246,7 @@ public class TestTaskMonitor {
     assertEquals(clone.getStatus(), monitor.getStatus());
     assertEquals(clone.toString(), monitor.toString());
     assertEquals(clone.toMap(), monitor.toMap());
-    assertEquals(clone.toJSON(), monitor.toJSON());
+    JSONAssert.assertEquals(clone.toJSON(), monitor.toJSON(),true);
 
     // mark complete and make param dirty
     monitor.markComplete("complete RPC");


### PR DESCRIPTION
`testClone` is detected as flaky by [NonDex](https://github.com/TestingResearchIllinois/NonDex) since the origin task monitor and the cloned one are represented as JSON objects, which are in a non-deterministic order. Therefore, I used JSONAssert to check if they are equal instead.