### PR TITLE
Bundle thirdparty deps

### DIFF
--- a/hubspot-client-bundles/hbase-client-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-client-bundle/pom.xml
@@ -81,11 +81,19 @@
                   <include>org.apache.hbase:hbase-logging</include>
                   <include>org.apache.hbase:hbase-protocol</include>
                   <include>org.apache.hbase:hbase-protocol-shaded</include>
+                  <!--
+                  need to include a bunch of thirdparty deps, otherwise we'd need
+                  to manage those versions in parent-pom
+                  -->
+                  <include>org.apache.hbase.thirdparty:*</include>
                   <!-- for AggregationClient. we filter to just client classes below -->
                   <include>org.apache.hbase:hbase-endpoint</include>
 
-                  <include>com.google.protobuf:protobuf-java</include>
+                  <!--
+                  following deps shaded in hubspot-client-bundles pom
+                  -->
 
+                  <include>com.google.protobuf:protobuf-java</include>
                   <!--  For client metrics we need to include so the metrics package can be shaded to prevent issues with our parent pom -->
                   <include>io.dropwizard.metrics:metrics-core</include>
                 </includes>

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
@@ -158,6 +158,31 @@
       <artifactId>protobuf-java</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-shaded-gson</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-shaded-protobuf</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-unsafe</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-shaded-miscellaneous</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-shaded-netty</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -177,6 +202,11 @@
                   list them above with scope provided.
                   -->
                   <include>org.apache.hbase:*</include>
+                  <!--
+                  need to include a bunch of thirdparty deps, otherwise we'd need
+                  to manage those versions in parent-pom
+                  -->
+                  <include>org.apache.hbase.thirdparty:*</include>
                 </includes>
               </artifactSet>
             </configuration>

--- a/hubspot-client-bundles/pom.xml
+++ b/hubspot-client-bundles/pom.xml
@@ -55,6 +55,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.4</version>
           <executions>
             <execution>
               <id>create-bundle-with-relocations</id>


### PR DESCRIPTION
I realized that we were missing hbase thirdparty deps in our bundle, so we were pulling them in transitively. This is annoying because those are on a different release cadence and different version scheme than the main hbase project. So we'd need to manage them in parent-pom separately from our main hbase version. Bundling them means that as we update hbase we'll automatically get whatever version of hbase-thirdparty it was meant to.