### PR TITLE
[Draft] Improving slow query log payload

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/OnlineLogRecord.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/OnlineLogRecord.java
@@ -71,6 +71,7 @@ final public class OnlineLogRecord extends LogEntry {
   private final int multiGetsCount;
   private final int multiMutationsCount;
   private final int multiServiceCalls;
+  private final String operationJson;
 
   public long getStartTime() {
     return startTime;
@@ -128,11 +129,15 @@ final public class OnlineLogRecord extends LogEntry {
     return multiServiceCalls;
   }
 
+  public String getOperationJson() {
+    return operationJson;
+  }
+
   private OnlineLogRecord(final long startTime, final int processingTime, final int queueTime,
     final long responseSize, final String clientAddress, final String serverClass,
     final String methodName, final String callDetails, final String param, final String regionName,
     final String userName, final int multiGetsCount, final int multiMutationsCount,
-    final int multiServiceCalls) {
+    final int multiServiceCalls, final String operationJson) {
     this.startTime = startTime;
     this.processingTime = processingTime;
     this.queueTime = queueTime;
@@ -147,6 +152,7 @@ final public class OnlineLogRecord extends LogEntry {
     this.multiGetsCount = multiGetsCount;
     this.multiMutationsCount = multiMutationsCount;
     this.multiServiceCalls = multiServiceCalls;
+    this.operationJson = operationJson;
   }
 
   public static class OnlineLogRecordBuilder {
@@ -164,6 +170,7 @@ final public class OnlineLogRecord extends LogEntry {
     private int multiGetsCount;
     private int multiMutationsCount;
     private int multiServiceCalls;
+    private String operationJson;
 
     public OnlineLogRecordBuilder setStartTime(long startTime) {
       this.startTime = startTime;
@@ -235,10 +242,15 @@ final public class OnlineLogRecord extends LogEntry {
       return this;
     }
 
+    public OnlineLogRecordBuilder setOperationJson(String operationJson) {
+      this.operationJson = operationJson;
+      return this;
+    }
+
     public OnlineLogRecord build() {
       return new OnlineLogRecord(startTime, processingTime, queueTime, responseSize, clientAddress,
         serverClass, methodName, callDetails, param, regionName, userName, multiGetsCount,
-        multiMutationsCount, multiServiceCalls);
+        multiMutationsCount, multiServiceCalls, operationJson);
     }
   }
 
@@ -261,7 +273,7 @@ final public class OnlineLogRecord extends LogEntry {
       .append(multiServiceCalls, that.multiServiceCalls).append(clientAddress, that.clientAddress)
       .append(serverClass, that.serverClass).append(methodName, that.methodName)
       .append(callDetails, that.callDetails).append(param, that.param)
-      .append(regionName, that.regionName).append(userName, that.userName).isEquals();
+      .append(regionName, that.regionName).append(userName, that.userName).append(operationJson, that.operationJson).isEquals();
   }
 
   @Override
@@ -269,7 +281,7 @@ final public class OnlineLogRecord extends LogEntry {
     return new HashCodeBuilder(17, 37).append(startTime).append(processingTime).append(queueTime)
       .append(responseSize).append(clientAddress).append(serverClass).append(methodName)
       .append(callDetails).append(param).append(regionName).append(userName).append(multiGetsCount)
-      .append(multiMutationsCount).append(multiServiceCalls).toHashCode();
+      .append(multiMutationsCount).append(multiServiceCalls).append(operationJson).toHashCode();
   }
 
   @Override
@@ -286,7 +298,8 @@ final public class OnlineLogRecord extends LogEntry {
       .append("callDetails", callDetails).append("param", param).append("regionName", regionName)
       .append("userName", userName).append("multiGetsCount", multiGetsCount)
       .append("multiMutationsCount", multiMutationsCount)
-      .append("multiServiceCalls", multiServiceCalls).toString();
+      .append("multiServiceCalls", multiServiceCalls)
+      .append("operationJson", operationJson).toString();
   }
 
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/SlowLogParams.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/SlowLogParams.java
@@ -32,15 +32,31 @@ public class SlowLogParams {
 
   private final String regionName;
   private final String params;
+  private final String operationJson;
 
-  public SlowLogParams(String regionName, String params) {
+  public SlowLogParams(
+    String regionName,
+    String params,
+    String operationJson
+  ) {
     this.regionName = regionName;
     this.params = params;
+    this.operationJson = operationJson;
+  }
+
+  public SlowLogParams(
+    String regionName,
+    String params
+  ) {
+    this.regionName = regionName;
+    this.params = params;
+    this.operationJson = StringUtils.EMPTY;
   }
 
   public SlowLogParams(String params) {
     this.regionName = StringUtils.EMPTY;
     this.params = params;
+    this.operationJson = StringUtils.EMPTY;
   }
 
   public String getRegionName() {
@@ -49,6 +65,10 @@ public class SlowLogParams {
 
   public String getParams() {
     return params;
+  }
+
+  public String getOperationJson() {
+    return operationJson;
   }
 
   @Override

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1634,6 +1634,14 @@ public final class HConstants {
     "hbase.regionserver.slowlog.systable.enabled";
   public static final boolean DEFAULT_SLOW_LOG_SYS_TABLE_ENABLED_KEY = false;
 
+  public static final String SLOW_LOG_OPERATION_JSON_MAX_COLS =
+    "hbase.regionserver.slowlog.operation.json.max.cols";
+  public static final int SLOW_LOG_OPERATION_JSON_MAX_COLS_DEFAULT = 50;
+
+  public static final String SLOW_LOG_OPERATION_JSON_ENABLED =
+    "hbase.regionserver.slowlog.operation.json.enabled";
+  public static final boolean SLOW_LOG_OPERATION_JSON_ENABLED_DEFAULT = false;
+
   public static final String SHELL_TIMESTAMP_FORMAT_EPOCH_KEY =
     "hbase.shell.timestamp.format.epoch";
 

--- a/hbase-protocol-shaded/src/main/protobuf/TooSlowLog.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/TooSlowLog.proto
@@ -43,6 +43,7 @@ message SlowLogPayload {
   optional int32 multi_mutations = 13 [default = 0];
   optional int32 multi_service_calls = 14 [default = 0];
   required Type type = 15;
+  optional string operation_json = 16;
 
   // SLOW_LOG is RPC call slow in nature whereas LARGE_LOG is RPC call quite large.
   // Majority of times, slow logs are also large logs and hence, ALL is combination of


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-27536

I've loaded the server changes onto a test host and verified the following two states:
* `hbase.regionserver.slowlog.operation.json.enabled` == false results in an empty string for `operationJson`
* `hbase.regionserver.slowlog.operation.json.enabled` == true results in an `operationJson` as expected.

Here's a picture of the entire `OnlineLogEntry` for a `Mutate` example:
![Screen Shot 2022-12-22 at 1 27 59 PM](https://user-images.githubusercontent.com/21689053/209202941-02324316-cffd-4a84-b027-4ffc397abcfd.png)

And here's a copy of the `operationJson` for a `Scan` example:
```
{
  "filter": "PageFilter 25",
  "startRow": "P\\x00\\x00\\x00",
  "stopRow": "`\\x00\\x00\\x00",
  "batch": -1,
  "cacheBlocks": false,
  "totalColumns": 0,
  "maxResultSize": "4194304",
  "families": {},
  "caching": 2147483647,
  "maxVersions": 1,
  "timeRange": [
    "0",
    "9223372036854775807"
  ]
}
```