### PR TITLE
Mark HBase RPMs as noarch

### DIFF
--- a/hbase-assembly/rpm-build/build.sh
+++ b/hbase-assembly/rpm-build/build.sh
@@ -38,6 +38,7 @@ rpmbuild \
     --define "hbase_version ${HBASE_VERSION}" \
     --define "release ${PKG_RELEASE}%{?dist}" \
     -bs --nodeps --buildroot="${SCRATCH_DIR}/INSTALL" \
+    --architecture all \
     ${SCRATCH_DIR}/SPECS/hbase.spec
 
 src_rpm=$(ls -1 ${SCRATCH_DIR}/SRPMS/hbase-*)
@@ -50,6 +51,7 @@ rpmbuild \
     --define "mvn_target_dir $RPM_DIR/../target" \
     --define "hbase_version ${HBASE_VERSION}" \
     --define "release ${PKG_RELEASE}%{?dist}" \
+    --architecture all \
     --rebuild $src_rpm
 
 if [[ -d $RPMS_OUTPUT_DIR ]]; then

--- a/hbase-assembly/rpm-build/build.sh
+++ b/hbase-assembly/rpm-build/build.sh
@@ -38,7 +38,6 @@ rpmbuild \
     --define "hbase_version ${HBASE_VERSION}" \
     --define "release ${PKG_RELEASE}%{?dist}" \
     -bs --nodeps --buildroot="${SCRATCH_DIR}/INSTALL" \
-    --architecture all \
     ${SCRATCH_DIR}/SPECS/hbase.spec
 
 src_rpm=$(ls -1 ${SCRATCH_DIR}/SRPMS/hbase-*)
@@ -51,7 +50,6 @@ rpmbuild \
     --define "mvn_target_dir $RPM_DIR/../target" \
     --define "hbase_version ${HBASE_VERSION}" \
     --define "release ${PKG_RELEASE}%{?dist}" \
-    --architecture all \
     --rebuild $src_rpm
 
 if [[ -d $RPMS_OUTPUT_DIR ]]; then

--- a/hbase-assembly/rpm-build/hbase.spec
+++ b/hbase-assembly/rpm-build/hbase.spec
@@ -40,6 +40,7 @@
 Name: hbase
 Version: %{hbase_version}
 Release: %{release}
+BuildArch: noarch
 Summary: HBase is the Hadoop database. Use it when you need random, realtime read/write access to your Big Data. This project's goal is the hosting of very large tables -- billions of rows X millions of columns -- atop clusters of commodity hardware. 
 URL: http://hbase.apache.org/
 Group: Systems/Daemons


### PR DESCRIPTION
I've poked around in the HBase repo and could not find any instance where native code is compiled as part of the HBase build process. I've poked around in `/usr/lib/hbase` on one of our RegionServers, and could not find any native code installed directly into the filesystem.

I did find a number of dependency JARs that provide native libraries inside them. All of these except one provide numerous builds so they work on a variety of architectures. The one exception is the brotli4j library, which only offers native support for x86-64, at least as our build process packages it. We could potentially change our build process to package more brotli JARs to close this gap. I don't believe Hubspot uses the related feature anyways.

I've tested running HBase out of this RPM on my personal cluster and it seems normal. I don't yet have the ability to set up an arm64 RegionServer to see how it behaves there.