### PR TITLE
Upload RPMs to CentOS 8 repos for both architectures

### DIFF
--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -10,8 +10,13 @@
 set -ex
 printenv
 
-HADOOP_DEP_VERSION="3.3.1"
-VERSION_ARGS="-Phadoop-3.0 -Dhadoop.profile=3.0 -Dhadoop-three.version=$HADOOP_DEP_VERSION"
+if [ $1 = "cdh5" ]; then
+  HADOOP_DEP_VERSION="2.6.0-cdh5.16.2"
+  VERSION_ARGS="-Phadoop-2.0 -Dhadoop-two.version=$HADOOP_DEP_VERSION"
+else
+  HADOOP_DEP_VERSION="3.3.1"
+  VERSION_ARGS="-Phadoop-3.0 -Dhadoop.profile=3.0 -Dhadoop-three.version=$HADOOP_DEP_VERSION"
+fi
 
 # We base the expected main branch and resulting maven version for clients on the hbase minor version
 # The reason for this is hbase re-branches for each minor release (2.4, 2.5, 2.6, etc). At each re-branch

--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -10,13 +10,8 @@
 set -ex
 printenv
 
-if [ $1 = "cdh5" ]; then
-  HADOOP_DEP_VERSION="2.6.0-cdh5.16.2"
-  VERSION_ARGS="-Phadoop-2.0 -Dhadoop-two.version=$HADOOP_DEP_VERSION"
-else
-  HADOOP_DEP_VERSION="3.3.1"
-  VERSION_ARGS="-Phadoop-3.0 -Dhadoop.profile=3.0 -Dhadoop-three.version=$HADOOP_DEP_VERSION"
-fi
+HADOOP_DEP_VERSION="3.3.1"
+VERSION_ARGS="-Phadoop-3.0 -Dhadoop.profile=3.0 -Dhadoop-three.version=$HADOOP_DEP_VERSION"
 
 # We base the expected main branch and resulting maven version for clients on the hbase minor version
 # The reason for this is hbase re-branches for each minor release (2.4, 2.5, 2.6, etc). At each re-branch
@@ -24,8 +19,6 @@ fi
 # The convention is a fork named "hubspot-$minorVersion", and the maven coordinates "$minorVersion-hubspot-SNAPSHOT"
 MINOR_VERSION="2.5"
 MAIN_BRANCH="hubspot-${MINOR_VERSION}"
-MAIN_YUM_REPO="6_hs-hbase"
-DEVELOP_YUM_REPO="6_hs-hbase-develop"
 
 # If we bump our hadoop build version, we should bump this as well
 # At some point it would be good to more closely link this to our hadoop build, but that can only happen
@@ -81,11 +74,9 @@ RELEASE="hs"
 
 if [[ "$GIT_BRANCH" = "$MAIN_BRANCH" ]]; then
     MAVEN_VERSION="${MINOR_VERSION}-hubspot-SNAPSHOT"
-    YUM_REPO=$MAIN_YUM_REPO
 elif [[ "$GIT_BRANCH" != "hubspot" ]]; then
     MAVEN_VERSION="${MINOR_VERSION}-${GIT_BRANCH}-SNAPSHOT"
     RELEASE="${RELEASE}~${GIT_BRANCH//[^[:alnum:]]/_}"
-    YUM_REPO=$DEVELOP_YUM_REPO
 else
     echo "Invalid git branch $GIT_BRANCH"
     exit 1
@@ -107,11 +98,9 @@ export MAVEN_ARGS='$MAVEN_ARGS'
 export SET_VERSION='$MAVEN_VERSION'
 export HBASE_VERSION='$HBASE_VERSION'
 export PKG_RELEASE='$RELEASE'
-export YUM_REPO='$YUM_REPO'
 export FULL_BUILD_VERSION='$FULL_BUILD_VERSION'
 EOF
 
 echo "Building HBase version $HBASE_VERSION"
 echo "Will use maven version $MAVEN_VERSION"
 echo "Will run maven with extra args $MAVEN_ARGS"
-echo "Will upload RPMs with version $FULL_BUILD_VERSION to $YUM_REPO"

--- a/hbase-assembly/.blazar.yaml
+++ b/hbase-assembly/.blazar.yaml
@@ -31,5 +31,4 @@ after:
 
     - description: "Publish RPM"
       commands:
-        - echo "Will upload to $YUM_REPO"
-        - rpm-upload --rpms-dir=$WORKSPACE/generated_rpms/ --repo-name $YUM_REPO
+        - ./rpm-build/upload-rpm.sh

--- a/hbase-assembly/rpm-build/upload-rpm.sh
+++ b/hbase-assembly/rpm-build/upload-rpm.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -x
+
+MINOR_VERSION="2.5"
+MAIN_BRANCH="hubspot-${MINOR_VERSION}"
+
+if [[ "$GIT_BRANCH" = "$MAIN_BRANCH" ]]; then
+   repos=( "8_hs-hbase" "aarch64_8_hs-hbase" )
+else
+    repos=( "8_hs-hbase-develop" "aarch64_8_hs-hbase-develop" )
+fi
+
+for repo in "${repos[@]}"; do
+  rpm-upload --rpms-dir=$WORKSPACE/generated_rpms/ --repo-name $repo
+done


### PR DESCRIPTION
When doing my previous PR to start creating `noarch` RPMs, I did not understand that I also needed to change where these RPMs get uploaded to. Our aarch64 machines only look for packages in dedicated aarch64 repos, even for `noarch` packages. 