### PR TITLE
Port HungConnectionTracker from cdh5 to BlockingRpcConnection

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/Call.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/Call.java
@@ -153,4 +153,17 @@ class Call {
   public long getStartTime() {
     return this.callStats.getStartTime();
   }
+
+  /**
+   * HubSpot modification: This isn't necessary for normal hbase client code, but is needed for
+   * {@link HungConnectionTracker}. We can delete this once that gets cleaned up.
+   */
+  public int getRemainingTime() {
+    if (timeout == 0) {
+      return Integer.MAX_VALUE;
+    }
+
+    int remaining = timeout - (int) (EnvironmentEdgeManager.currentTime() - getStartTime());
+    return remaining > 0 ? remaining : 0;
+  }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HungConnectionTracker.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HungConnectionTracker.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.ipc;
+
+import java.lang.reflect.Method;
+import java.net.Socket;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import org.apache.hadoop.hbase.net.Address;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HubSpot modification: This class tracks threads writing to an IPC connection and attempts to
+ * manually interrupt them if they significantly overshoot their call timeout. This class relies on
+ * the fact that track and complete are called within the RpcClient outLock. This ensure that we are
+ * only every tracking one thread per IPC client. We only open a single IPC client to each region
+ * server, so the number of total threads tracked at a single time should never exceed the total
+ * number of region servers the client is talking to. Note: this class is only necessary because of
+ * how we inject SSLSocketFactory into the underlying net code of the client. This was necessary for
+ * our haproxy SSL solution, but once we finish the hbase2 client upgrade we should be able to
+ * migrate onto native TLS and NettyRpcConnection. At that point we can delete this class and
+ * related methods.
+ */
+@InterfaceAudience.Private
+public class HungConnectionTracker {
+
+  private static final long CHECK_INTERVAL_MILLIS = 700;
+  private static final Logger LOG = LoggerFactory.getLogger(HungConnectionTracker.class);
+  private static final long INTERRUPT_BUFFER_WINDOW_NANOS = TimeUnit.MILLISECONDS.toNanos(1_000);
+  private static final boolean IS_TARGET_JAVA_VERSION =
+    System.getProperty("java.specification.version").startsWith("11");
+
+  public static final LongAdder INTERRUPTED = new LongAdder();
+
+  private final ConcurrentHashMap<Thread, ConnectionData> trackedThreads;
+  private final Thread interrupterThread;
+
+  private Class<?> sslSocketImpl;
+  private Method socketCloseMethod;
+
+  public HungConnectionTracker() {
+    this.trackedThreads = new ConcurrentHashMap<>();
+    this.interrupterThread =
+      new Thread(this::processTrackedThreads, "hbase-hung-connection-interrupter");
+    this.interrupterThread.setDaemon(true);
+    this.interrupterThread.start();
+
+    // Using the normal `close` method on java SSL sockets attempts to send a `close_notify`. This
+    // causes our close to keep hanging since we are detecting when the network connection is
+    // impaired.
+    // We use reflection to access the raw close socket method and forcibly close the connection to
+    // the hbase server without a `close_notify`.
+    try {
+      this.sslSocketImpl = Class.forName("sun.security.ssl.SSLSocketImpl");
+      this.socketCloseMethod = sslSocketImpl.getDeclaredMethod("closeSocket", boolean.class);
+      this.socketCloseMethod.setAccessible(true);
+    } catch (NoSuchMethodException | ClassNotFoundException e) {
+      LOG.info("Couldn't find SSLSocketImpl.closeSocket(boolean) method", e);
+      this.sslSocketImpl = null;
+      this.socketCloseMethod = null;
+    }
+
+    // Since we are using reflection on an internal method, it's expected it could change from
+    // version to version. This ensures we don't see a strange impact
+    // on a major java version upgrade if the function keeps the same name but has a different
+    // impact.
+    if (!IS_TARGET_JAVA_VERSION) {
+      LOG.info(
+        "Current java version does not matched desired version, skipping reflection based close");
+      this.sslSocketImpl = null;
+      this.socketCloseMethod = null;
+    }
+  }
+
+  public void track(Thread thread, Call call, Address address, Socket socket) {
+    trackedThreads.put(thread, new ConnectionData(System.nanoTime(), call, address, socket));
+  }
+
+  public void complete(Thread thread) {
+    trackedThreads.remove(thread);
+  }
+
+  private void processTrackedThreads() {
+    while (true) {
+      try {
+        Thread.sleep(CHECK_INTERVAL_MILLIS);
+      } catch (InterruptedException e) {
+        LOG.info("Interrupted", e);
+      }
+
+      try {
+        for (Entry<Thread, ConnectionData> connectionEntry : trackedThreads.entrySet()) {
+          ConnectionData connectionData = connectionEntry.getValue();
+          Thread hungThread = connectionEntry.getKey();
+          long durationNanos = System.nanoTime() - connectionData.getStartTimeNanos();
+
+          if (durationNanos > connectionData.getRemainingTimeNanos()) {
+            LOG.info(
+              "Detected hung connection on thread={} callId={} to server={} executingFor={} ms. Attempting to close the socket and interrupt the thread.",
+              hungThread.getName(), connectionData.getCall().id, connectionData.getServerName(),
+              TimeUnit.NANOSECONDS.toMillis(durationNanos));
+
+            try {
+              connectionData.getSocket().setSoLinger(true, 0);
+
+              // Our SSL sockets don't work will when the upstream has closed. We use reflection to
+              // force the underlying socket to close faster.
+              if (
+                socketCloseMethod != null && sslSocketImpl.isInstance(connectionData.getSocket())
+              ) {
+                LOG.debug("Invoking SSLSocketImpl.closeSocket(boolean)");
+                socketCloseMethod.invoke(connectionData.getSocket(), false);
+              } else {
+                LOG.debug("Invoking Socket.close");
+                connectionData.getSocket().close();
+              }
+
+              INTERRUPTED.increment();
+              hungThread.interrupt();
+            } finally {
+              complete(hungThread);
+            }
+          }
+        }
+      } catch (Exception e) {
+        LOG.info("Failed to process threads", e);
+      }
+    }
+  }
+
+  private final class ConnectionData {
+    private final long startTimeNanos;
+    private final Call call;
+    private final long remainingTimeNanos;
+    private final Address address;
+    private final Socket socket;
+
+    private ConnectionData(long startTimeNanos, Call call, Address address, Socket socket) {
+      this.startTimeNanos = startTimeNanos;
+      this.call = call;
+      this.remainingTimeNanos =
+        TimeUnit.MILLISECONDS.toNanos(call.getRemainingTime()) + INTERRUPT_BUFFER_WINDOW_NANOS;
+      this.address = address;
+      this.socket = socket;
+    }
+
+    public long getStartTimeNanos() {
+      return startTimeNanos;
+    }
+
+    public Call getCall() {
+      return call;
+    }
+
+    public long getRemainingTimeNanos() {
+      return remainingTimeNanos;
+    }
+
+    public String getServerName() {
+      return address.toString();
+    }
+
+    public Socket getSocket() {
+      return socket;
+    }
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/MockOutputStreamWithTimeout.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/MockOutputStreamWithTimeout.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.ipc;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InterfaceAudience.Private
+public class MockOutputStreamWithTimeout extends OutputStream {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MockOutputStreamWithTimeout.class);
+
+  private static final DataOutputStream INSTANCE =
+    new DataOutputStream(new MockOutputStreamWithTimeout());
+
+  private static final AtomicBoolean SHOULD_FAIL = new AtomicBoolean(false);
+  private static final AtomicBoolean IS_SLEEPING = new AtomicBoolean(false);
+
+  public static DataOutputStream maybeMock(DataOutputStream defaultStream) {
+    if (SHOULD_FAIL.get()) {
+      return INSTANCE;
+    } else {
+      return defaultStream;
+    }
+  }
+
+  public static void enable() {
+    SHOULD_FAIL.set(true);
+  }
+
+  public static void disable() {
+    SHOULD_FAIL.set(false);
+  }
+
+  public static boolean isSleeping() {
+    return IS_SLEEPING.get();
+  }
+
+  public static void awaitSleepingState() {
+    synchronized (IS_SLEEPING) {
+      while (!IS_SLEEPING.get()) {
+        LOG.info("Waiting for stream to enter sleeping state");
+        try {
+          IS_SLEEPING.wait();
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    try {
+      LOG.info("Sleeping");
+      synchronized (IS_SLEEPING) {
+        IS_SLEEPING.set(true);
+        IS_SLEEPING.notifyAll();
+      }
+      Thread.sleep(60_000);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    LOG.info("Done - throwing exception");
+    throw new SocketTimeoutException("from test");
+
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestHungConnectionTracker.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestHungConnectionTracker.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.ipc;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.testclassification.ClientTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category({ MediumTests.class, ClientTests.class })
+public class TestHungConnectionTracker {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestHungConnectionTracker.class);
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestHungConnectionTracker.class);
+
+  private final static HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    TEST_UTIL.startMiniCluster();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testBlocking() throws IOException, InterruptedException {
+    TEST_UTIL.createTable(TableName.valueOf("foo"), "0");
+    Configuration conf = new Configuration(TEST_UTIL.getConfiguration());
+    conf.set(RpcClientFactory.CUSTOM_RPC_CLIENT_IMPL_CONF_KEY, BlockingRpcClient.class.getName());
+    conf.setInt(HConstants.HBASE_RPC_TIMEOUT_KEY, 5_000);
+    conf.setInt(HConstants.HBASE_RPC_READ_TIMEOUT_KEY, 5_000);
+
+    Connection conn = ConnectionFactory.createConnection(conf);
+    Table table = conn.getTable(TableName.valueOf("foo"));
+
+    // warm meta
+    table.getRegionLocator().getAllRegionLocations();
+
+    MockOutputStreamWithTimeout.enable();
+
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    Thread blockedThread = new Thread(() -> {
+      try {
+        LOG.info("Executing hanging get");
+        table.get(new Get(Bytes.toBytes("foo")));
+        LOG.info("Done hanging get");
+        future.complete(null);
+      } catch (Throwable e) {
+        future.completeExceptionally(e);
+        LOG.info("Hanging get failed", e);
+      }
+    });
+    blockedThread.start();
+
+    MockOutputStreamWithTimeout.awaitSleepingState();
+    MockOutputStreamWithTimeout.disable();
+
+    LOG.info("Executing test get");
+    table.get(new Get(Bytes.toBytes("foo")));
+    LOG.info("Test get done");
+
+    // actually expect no error here because the hung connection will have been retried
+    future.join();
+
+    assertEquals(1, HungConnectionTracker.INTERRUPTED.sum());
+  }
+}


### PR DESCRIPTION
Per critsit 3132, we need to support interrupting socket.write calls due to our use of SSL sockets. SSL sockets do not honor write timeout. We discovered this in cdh5 and wrote the HungConnectionTracker to handle interrupting those.  I did not port that to hbase2 initially, because it seemed that hbase2's TimerTask-based timeout system would handle this. Unfortunately it did not due to synchronization, but also it doesn't actually close the connection.

Once we finish upgrading to hbase2, we will want to move onto NettyRpcConnection and integrate with hbase's new native TLS. At that point we can ditch this entire patch.

I added a test which verifies that the HungConnectionTracker properly interrupts these hung writes. I'm currently running a larger suite of tests, and will merge this once those all are confirmed to pass.