### PR TITLE
Add Java 17 support to the HungConnectionTracker

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HungConnectionTracker.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HungConnectionTracker.java
@@ -46,8 +46,15 @@ public class HungConnectionTracker {
   private static final long CHECK_INTERVAL_MILLIS = 700;
   private static final Logger LOG = LoggerFactory.getLogger(HungConnectionTracker.class);
   private static final long INTERRUPT_BUFFER_WINDOW_NANOS = TimeUnit.MILLISECONDS.toNanos(1_000);
-  private static final boolean IS_TARGET_JAVA_VERSION =
-    System.getProperty("java.specification.version").startsWith("11");
+  private static final String[] SUPPORTED_JAVA_VERSIONS = { "11", "17" };
+  private static boolean IS_TARGET_JAVA_VERSION;
+  static {
+    for (String v : SUPPORTED_JAVA_VERSIONS) {
+      if (System.getProperty("java.specification.version").startsWith(v)) {
+        IS_TARGET_JAVA_VERSION = true;
+      }
+    }
+  }
 
   public static final LongAdder INTERRUPTED = new LongAdder();
 


### PR DESCRIPTION
The HungConnectionTracker can be easily ported to Java 17. The `SSLSocketImpl#closeSocket` method that it calls does not show any changes aside from logging between the two JDK versions:
- https://github.com/openjdk/jdk/blob/jdk-11+17/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java#L1592
- https://github.com/openjdk/jdk/blob/jdk-17+7/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java#L1751