### PR TITLE
add a config for using the legacy methods

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
@@ -794,6 +794,14 @@ public final class CommonFSUtils {
    */
   public static FSDataOutputStream createForWal(FileSystem fs, Path path, boolean overwrite,
     int bufferSize, short replication, long blockSize, boolean isRecursive) throws IOException {
+    // temporary for use while we work on upgrading clients to hadoop3
+    if (fs.getConf().getBoolean("use.legacy.hdfs.create.methods", false)) {
+      if (isRecursive) {
+        return fs.create(path, overwrite, bufferSize, replication, blockSize);
+      } else {
+        return fs.createNonRecursive(path, overwrite, bufferSize, replication, blockSize, null);
+      }
+    }
     FSDataOutputStreamBuilder<?, ?> builder = fs.createFile(path).overwrite(overwrite)
       .bufferSize(bufferSize).replication(replication).blockSize(blockSize);
     if (isRecursive) {


### PR DESCRIPTION
@rmdmattingly I'm going to merge this so that we don't have to keep snapshot scanning pinned to a branch.  This code is not in the hot path, so I don't think the conf lookup is an issue. Otherwise it's fully gated, so shouldn't affect servers at all.