### PR TITLE
Add more debug output for hung connections and timed out multis

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MultiServerCallable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MultiServerCallable.java
@@ -48,13 +48,15 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos.RegionActi
 @InterfaceAudience.Private
 class MultiServerCallable extends CancellableRegionServerCallable<MultiResponse> {
   private MultiAction multiAction;
+  private final int numAttempt;
   private boolean cellBlock;
 
   MultiServerCallable(final ClusterConnection connection, final TableName tableName,
     final ServerName location, final MultiAction multi, RpcController rpcController, int rpcTimeout,
-    RetryingTimeTracker tracker, int priority) {
+    RetryingTimeTracker tracker, int priority, int numAttempt) {
     super(connection, tableName, null, rpcController, rpcTimeout, tracker, priority);
     this.multiAction = multi;
+    this.numAttempt = numAttempt;
     // RegionServerCallable has HRegionLocation field, but this is a multi-region request.
     // Using region info from parent HRegionLocation would be a mistake for this class; so
     // we will store the server here, and throw if someone tries to obtain location/regioninfo.
@@ -150,5 +152,9 @@ class MultiServerCallable extends CancellableRegionServerCallable<MultiResponse>
 
   ServerName getServerName() {
     return location.getServerName();
+  }
+
+  public int getNumAttempt() {
+    return numAttempt;
   }
 }


### PR DESCRIPTION
My intent is to eventually revert this PR, but for now we need additional diagnostics around these points:

1. For multis, we often get vague SocketTimeoutException which can be confusing. I added some additional output to that exception, including how many actions remaining on which servers after how many attempts.
2. Also for multis, we see the `Cannot get replica` error which is also confusing. I added a caused by to that message, which will probably most commonly be related to operation timeout
3. Adds a bunch more debug/trace logging around HungConnectionTracker while we try to dig into hung threads there.

I've run all of the RPC and Client unit tests, and also deployed to scenario tester without issues.