### PR TITLE
Fixes the ClientSideRegionScanner to actually respect the nextRaw API

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
@@ -48,6 +48,7 @@ public class ClientSideRegionScanner extends AbstractClientScanner {
   private HRegion region;
   RegionScanner scanner;
   List<Cell> values;
+  boolean hasMore = true;
 
   public ClientSideRegionScanner(Configuration conf, FileSystem fs, Path rootDir,
     TableDescriptor htd, RegionInfo hri, Scan scan, ScanMetrics scanMetrics) throws IOException {
@@ -90,11 +91,15 @@ public class ClientSideRegionScanner extends AbstractClientScanner {
 
   @Override
   public Result next() throws IOException {
-    values.clear();
-    scanner.nextRaw(values);
-    if (values.isEmpty()) {
-      // we are done
-      return null;
+    while (true) {
+      if (!hasMore) {
+        return null;
+      }
+      values.clear();
+      this.hasMore = scanner.nextRaw(values);
+      if (!values.isEmpty()) {
+        break;
+      }
     }
 
     Result result = Result.create(values);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
@@ -443,7 +443,7 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
       boolean shouldStop = shouldStop(current);
       // When has filter row is true it means that the all the cells for a particular row must be
       // read before a filtering decision can be made. This means that filters where hasFilterRow
-      // run the risk of enLongAddering out of memory errors in the case that they are applied to a
+      // run the risk of encountering out of memory errors in the case that they are applied to a
       // table that has very large rows.
       boolean hasFilterRow = this.filter != null && this.filter.hasFilterRow();
 


### PR DESCRIPTION
The nextRaw API has the following contract:

  nextRaw(List<Cell> kvs) -> boolean (hasMore)

The intent is that one needs to continue to call nextRaw() repeatedly until the hasMore signal returns false (though it can return false and the caller will still have the last row).

The ClientSideRegionScanner treated any empty kvs list as a sentinel that the scan should be completed for this region. This is incorrect, and breaks pretty badly when filters might cause the nextRaw to return empty results that need to be skipped.

This change moves the client scanner to follow the contract as required by the nextRaw method. We add a private field to track whether hasMore is false, and will repeatedly call nextRaw to get a non-empty result (in order to behave similarly to how it's behaved in the past).