### PR TITLE
Create RPM with zstd compression

### DIFF
--- a/hbase-assembly/rpm-build/hbase.spec
+++ b/hbase-assembly/rpm-build/hbase.spec
@@ -37,6 +37,10 @@
 # Disable debuginfo package
 %define debug_package %{nil}
 
+# HubSpot: use zstd because it decompresses much faster
+%define _binary_payload w19.zstdio
+%define _source_payload w19.zstdio
+
 Name: hbase
 Version: %{hbase_version}
 Release: %{release}


### PR DESCRIPTION
This option recently became available to us when Blazar started running Java builds on CentOS 8. This will make installation of the HBase packages faster.