### PR TITLE
Add hbase-shaded-netty-tcnative to our client and server bundles

### DIFF
--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -34,6 +34,10 @@
     <license.bundles.dependencies>true</license.bundles.dependencies>
   </properties>
   <dependencies>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-netty-tcnative</artifactId>
+    </dependency>
     <!--
       Added by HubSpot since this module was in the original hadoop-three-compat moduleSet include list,
       which is now converted to a dependencySet.

--- a/hbase-shaded/hbase-shaded-netty-tcnative/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-netty-tcnative/.blazar.yaml
@@ -1,0 +1,16 @@
+buildpack:
+  name: Blazar-Buildpack-Java
+
+# Note: this blazar yaml has been copied to all of the maven submodules (EXCEPT hbase-assembly) so
+# that they can be properly configured. If you make changes to this, you will need to make sure all
+# submodules are also updated accordingly. If you added a new submodule, you'll need to make sure
+# it gets a copy of this .blazar.yaml. In either case, use copy_blazar_yaml.sh to copy to all
+# subdirs containing a pom.xml.
+# Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
+# Prefer making changes to prepare_environment.sh instead, if possible.
+
+
+before:
+  - description: "Prepare build environment"
+    commands:
+      - $WORKSPACE/build-scripts/prepare_environment.sh

--- a/hbase-shaded/hbase-shaded-netty-tcnative/pom.xml
+++ b/hbase-shaded/hbase-shaded-netty-tcnative/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+      /**
+       * Licensed to the Apache Software Foundation (ASF) under one
+       * or more contributor license agreements.  See the NOTICE file
+       * distributed with this work for additional information
+       * regarding copyright ownership.  The ASF licenses this file
+       * to you under the Apache License, Version 2.0 (the
+       * "License"); you may not use this file except in compliance
+       * with the License.  You may obtain a copy of the License at
+       *
+       *     http://www.apache.org/licenses/LICENSE-2.0
+       *
+       * Unless required by applicable law or agreed to in writing, software
+       * distributed under the License is distributed on an "AS IS" BASIS,
+       * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       * See the License for the specific language governing permissions and
+       * limitations under the License.
+       */
+      -->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-shaded</artifactId>
+    <version>${revision}</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>hbase-shaded-netty-tcnative</artifactId>
+  <name>Apache HBase - Shaded - Netty tcnative</name>
+  <properties>
+    <tcnative.version>2.0.61.Final</tcnative.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${tcnative.version}</version>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>${tcnative.version}</version>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!--Make it so assembly:single does nothing in here-->
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <skipAssembly>true</skipAssembly>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <shadeSourcesContent>true</shadeSourcesContent>
+              <createSourcesJar>true</createSourcesJar>
+              <relocations>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>org.apache.hbase.thirdparty.io.netty</shadedPattern>
+                </relocation>
+              </relocations>
+              <artifactSet>
+                <includes>
+                  <include>io.netty:*</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!--This trick from
+             https://stackoverflow.com/questions/33825743/rename-files-inside-a-jar-using-some-maven-plugin
+
+            The netty jar has a .so in it. Shading requires rename of the .so and then passing a system
+            property so netty finds the renamed .so and associates it w/ the relocated netty files.
+
+            Add this define when running unit tests:
+
+               mvn test -Dorg.apache.hbase.thirdparty.io.netty.packagePrefix=org.apache.hbase.thirdparty. -Dtest=TestNettyIPC
+
+            See toward the end of this issue for how to pass config:
+
+              https://github.com/netty/netty/issues/6665
+
+            TODO: Ensure native works.
+            NOTE: The 'tofile' in the move command below has the relocation hard-coded
+            with '-' instead of '.' separators. If change the relocation, need to change here too.
+          -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <echo message="unjar"/>
+                <unzip dest="${project.build.directory}/unpacked/" src="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
+                <echo message="Rename netty .so in META-INF"/>
+                <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_linux_x86_64.so" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_linux_x86_64.so"/>
+                <move file="${project.build.directory}/unpacked/META-INF/native/libnetty_tcnative_linux_aarch_64.so" tofile="${project.build.directory}/unpacked/META-INF/native/liborg_apache_hbase_thirdparty_netty_tcnative_linux_aarch_64.so"/>
+                <jar basedir="${project.build.directory}/unpacked" destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -31,6 +31,7 @@
   <name>Apache HBase - Shaded</name>
   <description>Module of HBase with most deps shaded.</description>
   <modules>
+    <module>hbase-shaded-netty-tcnative</module>
     <module>hbase-shaded-client-byo-hadoop</module>
     <module>hbase-shaded-client</module>
     <module>hbase-shaded-mapreduce</module>

--- a/hubspot-client-bundles/hbase-client-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-client-bundle/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -14,6 +12,10 @@
   <artifactId>hbase-client-bundle</artifactId>
 
   <dependencies>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-netty-tcnative</artifactId>
+    </dependency>
     <!--
     One main dependency: hbase-client. The rest pulled in transitively.
     Additionally, need hbase-endpoint for AggregationClient. We need to make sure it
@@ -86,6 +88,7 @@
                   to manage those versions in parent-pom
                   -->
                   <include>org.apache.hbase.thirdparty:*</include>
+                  <include>org.apache.hbase:hbase-shaded-netty-tcnative</include>
                   <!-- for AggregationClient. we filter to just client classes below -->
                   <include>org.apache.hbase:hbase-endpoint</include>
 

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
@@ -117,7 +117,7 @@
       </exclusions>
     </dependency>
 
-    <!-- 
+    <!--
     These are all provided by hbase-client-bundle. We set them as scope
     provided here so that they are excluded from the resulting dependency
     reduced pom. This should be kept in-sync with the inclusion list

--- a/hubspot-client-bundles/pom.xml
+++ b/hubspot-client-bundles/pom.xml
@@ -3,8 +3,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <artifactId>hbase-build-configuration</artifactId>
     <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-build-configuration</artifactId>
     <version>${revision}</version>
     <relativePath>../hbase-build-configuration</relativePath>
   </parent>
@@ -85,7 +85,7 @@
                     <pattern>com.codahale.metrics</pattern>
                     <shadedPattern>${shade.prefix}.com.codahale.metrics</shadedPattern>
                   </relocation>
-                  <!-- 
+                  <!--
                     This is a little brittle, but as far as I can tell this class list hasn't
                     really changed much. The core problem this solves is that our hadoop jobs
                     are executed with mapreduce.job.classloader.system.classes set, including
@@ -93,10 +93,10 @@
                     throw ClassNotFoundException because they aren't actually system classes
                     but are covered by that property. Another option would be to exclude
                     org.apache.hadoop.metrics2 from the system classes list, but there are a
-                    bunch of classes in there in hadoop and it's hard to know the implications 
+                    bunch of classes in there in hadoop and it's hard to know the implications
                     of that. So I decided to solve this for hbase by shading these classes
                     which are brought in by hbase-hadoop-compat and hbase-hadoop2-compat.
-                    These classes are used in snapshot scan jobs, because the metrics are 
+                    These classes are used in snapshot scan jobs, because the metrics are
                     initialized when opening an HFile for read.
                   -->
                   <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -1001,6 +1001,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-shaded-netty-tcnative</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-shaded-client</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
In order to use tcnative, it needs to be shaded to match our hbase-thirdparty relocations. This includes both the java classes and packaged native libs. I plan to get this upstreamed in hbase-thirdparty, but it will take a bit to do that. So this PR gets us an easily revertible temporary solution.

I also ran spotless on our custom modules so it matches the rest of hbase.