### PR TITLE
Build without RC file modifications

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -94,17 +94,11 @@ FULL_BUILD_VERSION="${HBASE_VERSION}-${RELEASE}"
 # could accurately reflect the full build version in the UI and elsewhere.
 MAVEN_ARGS="$MAVEN_ARGS -Dhubspot.build.version=$HBASE_VERSION"
 
-#
-# Dump generated env vars into rc file
-#
-
-cat >> "$BUILD_COMMAND_RC_FILE" <<EOF
-export MAVEN_ARGS='$MAVEN_ARGS'
-export SET_VERSION='$MAVEN_VERSION'
-export HBASE_VERSION='$HBASE_VERSION'
-export PKG_RELEASE='$RELEASE'
-export FULL_BUILD_VERSION='$FULL_BUILD_VERSION'
-EOF
+write-build-env-var MAVEN_ARGS "$MAVEN_ARGS"
+write-build-env-var SET_VERSION "$MAVEN_VERSION"
+write-build-env-var HBASE_VERSION "$HBASE_VERSION"
+write-build-env-var PKG_RELEASE "$RELEASE"
+write-build-env-var FULL_BUILD_VERSION "$FULL_BUILD_VERSION"
 
 echo "Building HBase version $HBASE_VERSION"
 echo "Will use maven version $MAVEN_VERSION"

--- a/hbase-annotations/.blazar.yaml
+++ b/hbase-annotations/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-annotations/.blazar.yaml
+++ b/hbase-annotations/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-annotations/.blazar.yaml
+++ b/hbase-annotations/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-archetypes/.blazar.yaml
+++ b/hbase-archetypes/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-archetypes/.blazar.yaml
+++ b/hbase-archetypes/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-archetypes/.blazar.yaml
+++ b/hbase-archetypes/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-archetypes/hbase-archetype-builder/.blazar.yaml
+++ b/hbase-archetypes/hbase-archetype-builder/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-archetypes/hbase-archetype-builder/.blazar.yaml
+++ b/hbase-archetypes/hbase-archetype-builder/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-archetypes/hbase-archetype-builder/.blazar.yaml
+++ b/hbase-archetypes/hbase-archetype-builder/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-archetypes/hbase-client-project/.blazar.yaml
+++ b/hbase-archetypes/hbase-client-project/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-archetypes/hbase-client-project/.blazar.yaml
+++ b/hbase-archetypes/hbase-client-project/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-archetypes/hbase-client-project/.blazar.yaml
+++ b/hbase-archetypes/hbase-client-project/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-archetypes/hbase-shaded-client-project/.blazar.yaml
+++ b/hbase-archetypes/hbase-shaded-client-project/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-archetypes/hbase-shaded-client-project/.blazar.yaml
+++ b/hbase-archetypes/hbase-shaded-client-project/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-archetypes/hbase-shaded-client-project/.blazar.yaml
+++ b/hbase-archetypes/hbase-shaded-client-project/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-assembly/.blazar.yaml
+++ b/hbase-assembly/.blazar.yaml
@@ -8,6 +8,11 @@ env:
   RPM_BUILD_COMMAND: "./rpm-build/build.sh"
   RPM_REPOS: "8_hs-hbase${GIT_NON_DEFAULT_BRANCH:+-develop} aarch64_8_hs-hbase${GIT_NON_DEFAULT_BRANCH:+-develop}"
   MAVEN_PHASE: package assembly:single
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-assembly/.blazar.yaml
+++ b/hbase-assembly/.blazar.yaml
@@ -10,7 +10,7 @@ env:
   MAVEN_PHASE: package assembly:single
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-asyncfs/.blazar.yaml
+++ b/hbase-asyncfs/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-asyncfs/.blazar.yaml
+++ b/hbase-asyncfs/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-asyncfs/.blazar.yaml
+++ b/hbase-asyncfs/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-backup/.blazar.yaml
+++ b/hbase-backup/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-backup/.blazar.yaml
+++ b/hbase-backup/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-backup/.blazar.yaml
+++ b/hbase-backup/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-build-configuration/.blazar.yaml
+++ b/hbase-build-configuration/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-build-configuration/.blazar.yaml
+++ b/hbase-build-configuration/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-build-configuration/.blazar.yaml
+++ b/hbase-build-configuration/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-checkstyle/.blazar.yaml
+++ b/hbase-checkstyle/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-checkstyle/.blazar.yaml
+++ b/hbase-checkstyle/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-checkstyle/.blazar.yaml
+++ b/hbase-checkstyle/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-client/.blazar.yaml
+++ b/hbase-client/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-client/.blazar.yaml
+++ b/hbase-client/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-client/.blazar.yaml
+++ b/hbase-client/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-common/.blazar.yaml
+++ b/hbase-common/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-common/.blazar.yaml
+++ b/hbase-common/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-common/.blazar.yaml
+++ b/hbase-common/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-compression/.blazar.yaml
+++ b/hbase-compression/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-compression/.blazar.yaml
+++ b/hbase-compression/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-compression/.blazar.yaml
+++ b/hbase-compression/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-compression/hbase-compression-aircompressor/.blazar.yaml
+++ b/hbase-compression/hbase-compression-aircompressor/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-compression/hbase-compression-aircompressor/.blazar.yaml
+++ b/hbase-compression/hbase-compression-aircompressor/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-compression/hbase-compression-aircompressor/.blazar.yaml
+++ b/hbase-compression/hbase-compression-aircompressor/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-compression/hbase-compression-brotli/.blazar.yaml
+++ b/hbase-compression/hbase-compression-brotli/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-compression/hbase-compression-brotli/.blazar.yaml
+++ b/hbase-compression/hbase-compression-brotli/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-compression/hbase-compression-brotli/.blazar.yaml
+++ b/hbase-compression/hbase-compression-brotli/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-compression/hbase-compression-lz4/.blazar.yaml
+++ b/hbase-compression/hbase-compression-lz4/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-compression/hbase-compression-lz4/.blazar.yaml
+++ b/hbase-compression/hbase-compression-lz4/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-compression/hbase-compression-lz4/.blazar.yaml
+++ b/hbase-compression/hbase-compression-lz4/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-compression/hbase-compression-snappy/.blazar.yaml
+++ b/hbase-compression/hbase-compression-snappy/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-compression/hbase-compression-snappy/.blazar.yaml
+++ b/hbase-compression/hbase-compression-snappy/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-compression/hbase-compression-snappy/.blazar.yaml
+++ b/hbase-compression/hbase-compression-snappy/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-compression/hbase-compression-xz/.blazar.yaml
+++ b/hbase-compression/hbase-compression-xz/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-compression/hbase-compression-xz/.blazar.yaml
+++ b/hbase-compression/hbase-compression-xz/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-compression/hbase-compression-xz/.blazar.yaml
+++ b/hbase-compression/hbase-compression-xz/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-compression/hbase-compression-zstd/.blazar.yaml
+++ b/hbase-compression/hbase-compression-zstd/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-compression/hbase-compression-zstd/.blazar.yaml
+++ b/hbase-compression/hbase-compression-zstd/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-compression/hbase-compression-zstd/.blazar.yaml
+++ b/hbase-compression/hbase-compression-zstd/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-endpoint/.blazar.yaml
+++ b/hbase-endpoint/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-endpoint/.blazar.yaml
+++ b/hbase-endpoint/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-endpoint/.blazar.yaml
+++ b/hbase-endpoint/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-examples/.blazar.yaml
+++ b/hbase-examples/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-examples/.blazar.yaml
+++ b/hbase-examples/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-examples/.blazar.yaml
+++ b/hbase-examples/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-external-blockcache/.blazar.yaml
+++ b/hbase-external-blockcache/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-external-blockcache/.blazar.yaml
+++ b/hbase-external-blockcache/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-external-blockcache/.blazar.yaml
+++ b/hbase-external-blockcache/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-hadoop-compat/.blazar.yaml
+++ b/hbase-hadoop-compat/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-hadoop-compat/.blazar.yaml
+++ b/hbase-hadoop-compat/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-hadoop-compat/.blazar.yaml
+++ b/hbase-hadoop-compat/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-hadoop2-compat/.blazar.yaml
+++ b/hbase-hadoop2-compat/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-hadoop2-compat/.blazar.yaml
+++ b/hbase-hadoop2-compat/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-hadoop2-compat/.blazar.yaml
+++ b/hbase-hadoop2-compat/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-hbtop/.blazar.yaml
+++ b/hbase-hbtop/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-hbtop/.blazar.yaml
+++ b/hbase-hbtop/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-hbtop/.blazar.yaml
+++ b/hbase-hbtop/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-http/.blazar.yaml
+++ b/hbase-http/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-http/.blazar.yaml
+++ b/hbase-http/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-http/.blazar.yaml
+++ b/hbase-http/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-it/.blazar.yaml
+++ b/hbase-it/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-it/.blazar.yaml
+++ b/hbase-it/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-it/.blazar.yaml
+++ b/hbase-it/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-logging/.blazar.yaml
+++ b/hbase-logging/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-logging/.blazar.yaml
+++ b/hbase-logging/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-logging/.blazar.yaml
+++ b/hbase-logging/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-mapreduce/.blazar.yaml
+++ b/hbase-mapreduce/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-mapreduce/.blazar.yaml
+++ b/hbase-mapreduce/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-mapreduce/.blazar.yaml
+++ b/hbase-mapreduce/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-metrics-api/.blazar.yaml
+++ b/hbase-metrics-api/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-metrics-api/.blazar.yaml
+++ b/hbase-metrics-api/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-metrics-api/.blazar.yaml
+++ b/hbase-metrics-api/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-metrics/.blazar.yaml
+++ b/hbase-metrics/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-metrics/.blazar.yaml
+++ b/hbase-metrics/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-metrics/.blazar.yaml
+++ b/hbase-metrics/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-procedure/.blazar.yaml
+++ b/hbase-procedure/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-procedure/.blazar.yaml
+++ b/hbase-procedure/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-procedure/.blazar.yaml
+++ b/hbase-procedure/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-protocol-shaded/.blazar.yaml
+++ b/hbase-protocol-shaded/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-protocol-shaded/.blazar.yaml
+++ b/hbase-protocol-shaded/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-protocol-shaded/.blazar.yaml
+++ b/hbase-protocol-shaded/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-protocol/.blazar.yaml
+++ b/hbase-protocol/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-protocol/.blazar.yaml
+++ b/hbase-protocol/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-protocol/.blazar.yaml
+++ b/hbase-protocol/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-replication/.blazar.yaml
+++ b/hbase-replication/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-replication/.blazar.yaml
+++ b/hbase-replication/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-replication/.blazar.yaml
+++ b/hbase-replication/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-resource-bundle/.blazar.yaml
+++ b/hbase-resource-bundle/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-resource-bundle/.blazar.yaml
+++ b/hbase-resource-bundle/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-resource-bundle/.blazar.yaml
+++ b/hbase-resource-bundle/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-rest/.blazar.yaml
+++ b/hbase-rest/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-rest/.blazar.yaml
+++ b/hbase-rest/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-rest/.blazar.yaml
+++ b/hbase-rest/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-rsgroup/.blazar.yaml
+++ b/hbase-rsgroup/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-rsgroup/.blazar.yaml
+++ b/hbase-rsgroup/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-rsgroup/.blazar.yaml
+++ b/hbase-rsgroup/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-server/.blazar.yaml
+++ b/hbase-server/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-server/.blazar.yaml
+++ b/hbase-server/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-server/.blazar.yaml
+++ b/hbase-server/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/.blazar.yaml
+++ b/hbase-shaded/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/.blazar.yaml
+++ b/hbase-shaded/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/.blazar.yaml
+++ b/hbase-shaded/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/hbase-shaded-check-invariants/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-check-invariants/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/hbase-shaded-check-invariants/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-check-invariants/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/hbase-shaded-check-invariants/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-check-invariants/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/hbase-shaded-client-byo-hadoop/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-client-byo-hadoop/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/hbase-shaded-client-byo-hadoop/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-client-byo-hadoop/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/hbase-shaded-client-byo-hadoop/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-client-byo-hadoop/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/hbase-shaded-client/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-client/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/hbase-shaded-client/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-client/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/hbase-shaded-client/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-client/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/hbase-shaded-mapreduce/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-mapreduce/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/hbase-shaded-mapreduce/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-mapreduce/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/hbase-shaded-mapreduce/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-mapreduce/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/hbase-shaded-netty-tcnative/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-netty-tcnative/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/hbase-shaded-netty-tcnative/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-netty-tcnative/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/hbase-shaded-netty-tcnative/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-netty-tcnative/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/hbase-shaded-testing-util-tester/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-testing-util-tester/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/hbase-shaded-testing-util-tester/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-testing-util-tester/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/hbase-shaded-testing-util-tester/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-testing-util-tester/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/hbase-shaded-testing-util/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-testing-util/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/hbase-shaded-testing-util/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-testing-util/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/hbase-shaded-testing-util/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-testing-util/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/.blazar.yaml
+++ b/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-shell/.blazar.yaml
+++ b/hbase-shell/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-shell/.blazar.yaml
+++ b/hbase-shell/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-shell/.blazar.yaml
+++ b/hbase-shell/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-testing-util/.blazar.yaml
+++ b/hbase-testing-util/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-testing-util/.blazar.yaml
+++ b/hbase-testing-util/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-testing-util/.blazar.yaml
+++ b/hbase-testing-util/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-thrift/.blazar.yaml
+++ b/hbase-thrift/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-thrift/.blazar.yaml
+++ b/hbase-thrift/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-thrift/.blazar.yaml
+++ b/hbase-thrift/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hbase-zookeeper/.blazar.yaml
+++ b/hbase-zookeeper/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hbase-zookeeper/.blazar.yaml
+++ b/hbase-zookeeper/.blazar.yaml
@@ -9,6 +9,9 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+# The build environment requires environment variables to be explicitly defined before they may
+# be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
+# throughout a build
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""

--- a/hbase-zookeeper/.blazar.yaml
+++ b/hbase-zookeeper/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hubspot-client-bundles/.blazar.yaml
+++ b/hubspot-client-bundles/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hubspot-client-bundles/.blazar.yaml
+++ b/hubspot-client-bundles/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hubspot-client-bundles/hbase-backup-restore-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-backup-restore-bundle/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hubspot-client-bundles/hbase-backup-restore-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-backup-restore-bundle/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hubspot-client-bundles/hbase-client-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-client-bundle/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hubspot-client-bundles/hbase-client-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-client-bundle/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/.blazar.yaml
@@ -12,7 +12,7 @@ buildpack:
 env:
   MAVEN_ARGS: ""
   SET_VERSION: ""
-  HADOOP_VERSION: ""
+  HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
 

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/.blazar.yaml
@@ -9,6 +9,12 @@ buildpack:
 # Make sure to also check hbase-assembly/.blazar.yaml to see if any changes should be added there as well.
 # Prefer making changes to prepare_environment.sh instead, if possible.
 
+env:
+  MAVEN_ARGS: ""
+  SET_VERSION: ""
+  HADOOP_VERSION: ""
+  PKG_RELEASE: ""
+  FULL_BUILD_VERSION: ""
 
 before:
   - description: "Prepare build environment"


### PR DESCRIPTION
We're migrating builds away from using the build RC file for persisting environment variables and now have a utility to do that instead.