### PR TITLE
Some added tracing abilities for slow scans

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
@@ -340,8 +340,7 @@ public class ConnectionImplementation implements ClusterConnection, Closeable {
       this.rpcClient = RpcClientFactory.createClient(this.conf, this.clusterId, this.metrics,
         connectionAttributes);
       this.rpcControllerFactory = RpcControllerFactory.instantiate(conf);
-      this.rpcCallerFactory =
-        RpcRetryingCallerFactory.instantiate(conf, interceptor, this.stats, this.metrics);
+      this.rpcCallerFactory = RpcRetryingCallerFactory.instantiate(conf, this.metrics);
       this.asyncProcess = new AsyncProcess(this, conf, rpcCallerFactory, rpcControllerFactory);
 
       // Do we publish the status?
@@ -2196,8 +2195,7 @@ public class ConnectionImplementation implements ClusterConnection, Closeable {
 
   @Override
   public RpcRetryingCallerFactory getNewRpcRetryingCallerFactory(Configuration conf) {
-    return RpcRetryingCallerFactory.instantiate(conf, this.interceptor, this.getStatisticsTracker(),
-      metrics);
+    return RpcRetryingCallerFactory.instantiate(conf, metrics);
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HTable.java
@@ -1316,9 +1316,8 @@ public class HTable implements Table {
       final List<String> callbackErrorServers = new ArrayList<>();
       Object[] results = new Object[execs.size()];
 
-      AsyncProcess asyncProcess = new AsyncProcess(
-        connection, configuration, RpcRetryingCallerFactory.instantiate(configuration,
-          connection.getStatisticsTracker(), connection.getConnectionMetrics()),
+      AsyncProcess asyncProcess = new AsyncProcess(connection, configuration,
+        RpcRetryingCallerFactory.instantiate(configuration, connection.getConnectionMetrics()),
         RpcControllerFactory.instantiate(configuration));
 
       Batch.Callback<ClientProtos.CoprocessorServiceResult> resultsCallback =

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/SecureBulkLoadClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/SecureBulkLoadClient.java
@@ -70,7 +70,7 @@ public class SecureBulkLoadClient {
             return response.getBulkToken();
           }
         };
-      return RpcRetryingCallerFactory.instantiate(conn.getConfiguration(), null, null)
+      return RpcRetryingCallerFactory.instantiate(conn.getConfiguration(), null)
         .<String> newCaller().callWithRetries(callable, Integer.MAX_VALUE);
     } catch (Throwable throwable) {
       throw new IOException(throwable);
@@ -93,7 +93,7 @@ public class SecureBulkLoadClient {
             return null;
           }
         };
-      RpcRetryingCallerFactory.instantiate(conn.getConfiguration(), null, null).<Void> newCaller()
+      RpcRetryingCallerFactory.instantiate(conn.getConfiguration(), null).<Void> newCaller()
         .callWithRetries(callable, Integer.MAX_VALUE);
     } catch (Throwable throwable) {
       throw new IOException(throwable);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/ScanMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/ScanMetrics.java
@@ -47,6 +47,7 @@ public class ScanMetrics extends ServerSideScanMetrics {
   public static final String REGIONS_SCANNED_METRIC_NAME = "REGIONS_SCANNED";
   public static final String RPC_RETRIES_METRIC_NAME = "RPC_RETRIES";
   public static final String REMOTE_RPC_RETRIES_METRIC_NAME = "REMOTE_RPC_RETRIES";
+  public static final String THROTTLE_TIME_METRIC_NAME = "THROTTLE_TIME";
 
   /**
    * number of RPC calls
@@ -94,6 +95,8 @@ public class ScanMetrics extends ServerSideScanMetrics {
    * number of remote RPC retries
    */
   public final AtomicLong countOfRemoteRPCRetries = createCounter(REMOTE_RPC_RETRIES_METRIC_NAME);
+
+  public final AtomicLong throttleTime = createCounter(THROTTLE_TIME_METRIC_NAME);
 
   /**
    * constructor

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/ServerSideScanMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/ServerSideScanMetrics.java
@@ -49,6 +49,10 @@ public class ServerSideScanMetrics {
 
   public static final String BLOCK_BYTES_SCANNED_KEY_METRIC_NAME = "BLOCK_BYTES_SCANNED";
 
+  public static final String QUEUE_TIME_METRIC_NAME = "QUEUE_TIME";
+
+  public static final String FS_READ_TIME_METRIC_NAME = "FS_READ_TIME";
+
   /**
    * @deprecated As of release 2.0.0, this will be removed in HBase 3.0.0
    *             (<a href="https://issues.apache.org/jira/browse/HBASE-17886">HBASE-17886</a>). Use
@@ -79,6 +83,9 @@ public class ServerSideScanMetrics {
 
   public final AtomicLong countOfBlockBytesScanned =
     createCounter(BLOCK_BYTES_SCANNED_KEY_METRIC_NAME);
+
+  public final AtomicLong queueTime = createCounter(QUEUE_TIME_METRIC_NAME);
+  public final AtomicLong fsReadTime = createCounter(FS_READ_TIME_METRIC_NAME);
 
   public void setCounter(String counterName, long value) {
     AtomicLong c = this.counters.get(counterName);

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncProcess.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncProcess.java
@@ -248,7 +248,7 @@ public class TestAsyncProcess {
         });
 
       return new RpcRetryingCallerImpl<AbstractResponse>(100, 500, 10,
-        RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null) {
+        RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null, null) {
         @Override
         public AbstractResponse callWithoutRetries(RetryingCallable<AbstractResponse> callable,
           int callTimeout) throws IOException, RuntimeException {
@@ -309,7 +309,7 @@ public class TestAsyncProcess {
     private final IOException e;
 
     public CallerWithFailure(IOException e) {
-      super(100, 500, 100, RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null);
+      super(100, 500, 100, RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null, null);
       this.e = e;
     }
 
@@ -331,7 +331,7 @@ public class TestAsyncProcess {
     private MultiAction multi;
 
     public CallerWithRegionException(IOException e, MultiAction multi) {
-      super(100, 500, 100, RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null);
+      super(100, 500, 100, RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null, null);
       this.e = e;
       this.multi = multi;
     }
@@ -462,7 +462,7 @@ public class TestAsyncProcess {
       }
 
       return new RpcRetryingCallerImpl<AbstractResponse>(100, 500, 10,
-        RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null) {
+        RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null, null) {
         @Override
         public MultiResponse callWithoutRetries(RetryingCallable<AbstractResponse> callable,
           int callTimeout) throws IOException, RuntimeException {

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncProcessWithRegionException.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncProcessWithRegionException.java
@@ -223,7 +223,7 @@ public class TestAsyncProcessWithRegionException {
       });
       mr.addException(REGION_INFO.getRegionName(), IOE);
       return new RpcRetryingCallerImpl<AbstractResponse>(100, 500, 0,
-        RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null) {
+        RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 9, 0, null, null) {
         @Override
         public AbstractResponse callWithoutRetries(RetryingCallable<AbstractResponse> callable,
           int callTimeout) {

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestRpcRetryingCallerImpl.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestRpcRetryingCallerImpl.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hbase.CallDroppedException;
 import org.apache.hadoop.hbase.CallQueueTooBigException;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseServerException;
+import org.apache.hadoop.hbase.quotas.RpcThrottlingException;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.junit.ClassRule;
@@ -49,6 +50,11 @@ public class TestRpcRetryingCallerImpl {
     itUsesSpecialPauseForServerOverloaded(CallDroppedException.class);
   }
 
+  @Test
+  public void itUsesSpecialPauseForThrottleException() {
+    itUsesSpecialPauseForServerOverloaded(RpcThrottlingException.class);
+  }
+
   private void itUsesSpecialPauseForServerOverloaded(
     Class<? extends HBaseServerException> exceptionClass) throws Exception {
 
@@ -59,7 +65,7 @@ public class TestRpcRetryingCallerImpl {
     long specialPauseMillis = 2;
 
     RpcRetryingCallerImpl<Void> caller = new RpcRetryingCallerImpl<>(pauseMillis,
-      specialPauseMillis, 2, RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 0, 0, null);
+      specialPauseMillis, 2, RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 0, 0, null, null);
 
     RetryingCallable<Void> callable =
       new ThrowingCallable(CallQueueTooBigException.class, specialPauseMillis);

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestRpcRetryingCallerImpl.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestRpcRetryingCallerImpl.java
@@ -17,18 +17,22 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 import org.apache.hadoop.hbase.CallDroppedException;
 import org.apache.hadoop.hbase.CallQueueTooBigException;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseServerException;
+import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
 import org.apache.hadoop.hbase.quotas.RpcThrottlingException;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -51,12 +55,12 @@ public class TestRpcRetryingCallerImpl {
   }
 
   @Test
-  public void itUsesSpecialPauseForThrottleException() {
+  public void itUsesSpecialPauseForThrottleException() throws Exception {
     itUsesSpecialPauseForServerOverloaded(RpcThrottlingException.class);
   }
 
-  private void itUsesSpecialPauseForServerOverloaded(
-    Class<? extends HBaseServerException> exceptionClass) throws Exception {
+  private void itUsesSpecialPauseForServerOverloaded(Class<? extends Exception> exceptionClass)
+    throws Exception {
 
     // the actual values don't matter here as long as they're distinct.
     // the ThrowingCallable will assert that the passed in pause from RpcRetryingCallerImpl
@@ -64,26 +68,61 @@ public class TestRpcRetryingCallerImpl {
     long pauseMillis = 1;
     long specialPauseMillis = 2;
 
-    RpcRetryingCallerImpl<Void> caller = new RpcRetryingCallerImpl<>(pauseMillis,
-      specialPauseMillis, 2, RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 0, 0, null, null);
+    ScanMetrics scanMetrics = new ScanMetrics();
+    RpcRetryingCallerImpl<Void> caller =
+      new RpcRetryingCallerImpl<>(pauseMillis, specialPauseMillis, 2,
+        RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, 0, 0, null, scanMetrics);
 
-    RetryingCallable<Void> callable =
-      new ThrowingCallable(CallQueueTooBigException.class, specialPauseMillis);
+    RetryingCallable<Void> callable;
+    if (HBaseServerException.class.isAssignableFrom(exceptionClass)) {
+      callable = new ThrowingCallable(() -> construct(exceptionClass), specialPauseMillis);
+    } else if (exceptionClass.equals(RpcThrottlingException.class)) {
+      callable = new ThrowingCallable(() -> new RpcThrottlingException(
+        RpcThrottlingException.Type.NumReadRequestsExceeded, 1000, "test"), -1);
+    } else {
+      throw new RuntimeException("Unexpected exceptionClass type " + exceptionClass.getName());
+    }
+
+    long start = System.currentTimeMillis();
     try {
       caller.callWithRetries(callable, 5000);
       fail("Expected " + exceptionClass.getSimpleName());
     } catch (RetriesExhaustedException e) {
-      assertTrue(e.getCause() instanceof HBaseServerException);
+      assertEquals(e.getCause().getClass(), exceptionClass);
+      long duration = System.currentTimeMillis() - start;
+      // we set a waitTime of 1s for the throttle exception above
+      // other exceptions only have a backoff time of 2ms. we can validate that we backoff
+      // appropriately by using a conservative in the middle threshold of 500ms.
+      if (e.getCause() instanceof RpcThrottlingException) {
+        Matcher<Long> durationMatcher = Matchers.greaterThan(500L);
+        assertThat(duration, durationMatcher);
+        // expect to see it accumulated in the scanMetrics as well.
+        assertThat(scanMetrics.throttleTime.get(), durationMatcher);
+      } else {
+        Matcher<Long> durationMatcher =
+          Matchers.allOf(Matchers.lessThan(500L), Matchers.greaterThan(0L));
+        assertThat(duration, durationMatcher);
+        // expect to see it accumulated in the scanMetrics as well.
+        assertThat(scanMetrics.throttleTime.get(), durationMatcher);
+      }
+    }
+  }
+
+  private <T extends Exception> T construct(Class<T> clazz) {
+    try {
+      return clazz.getConstructor().newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 
   private static class ThrowingCallable implements RetryingCallable<Void> {
-    private final Class<? extends HBaseServerException> exceptionClass;
+    private final Supplier<? extends Exception> exceptionSupplier;
     private final long specialPauseMillis;
 
-    public ThrowingCallable(Class<? extends HBaseServerException> exceptionClass,
+    public ThrowingCallable(Supplier<? extends Exception> exceptionSupplier,
       long specialPauseMillis) {
-      this.exceptionClass = exceptionClass;
+      this.exceptionSupplier = exceptionSupplier;
       this.specialPauseMillis = specialPauseMillis;
     }
 
@@ -104,13 +143,17 @@ public class TestRpcRetryingCallerImpl {
 
     @Override
     public long sleep(long pause, int tries) {
-      assertEquals(pause, specialPauseMillis);
+      if (specialPauseMillis < 0) {
+        fail("Should not have called with a sleep, but got " + pause + " and tries=" + tries);
+      } else {
+        assertEquals(pause, specialPauseMillis);
+      }
       return 0;
     }
 
     @Override
     public Void call(int callTimeout) throws Exception {
-      throw exceptionClass.getConstructor().newInstance();
+      throw exceptionSupplier.get();
     }
   }
 }

--- a/hbase-protocol-shaded/src/main/protobuf/TooSlowLog.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/TooSlowLog.proto
@@ -53,6 +53,8 @@ message SlowLogPayload {
   repeated NameBytesPair connection_attribute = 18;
   repeated NameBytesPair request_attribute = 19;
 
+  optional int64 fs_read_time = 20;
+
   // SLOW_LOG is RPC call slow in nature whereas LARGE_LOG is RPC call quite large.
   // Majority of times, slow logs are also large logs and hence, ALL is combination of
   // both

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -192,7 +192,12 @@ public final class HFile {
     return CHECKSUM_FAILURES.sum();
   }
 
-  public static final void updateReadLatency(long latencyMillis, boolean pread) {
+  public static final void updateReadLatency(long latencyMillis, boolean pread,
+    int slowReadThresholdMs, String hFileName, long offset, int onDiskSizeWithHeader) {
+    if (latencyMillis > slowReadThresholdMs) {
+      LOG.warn("Slow read: hfileName={}, offset={}, size={}, pread={}, durationMillis={}",
+        hFileName, offset, onDiskSizeWithHeader, pread, latencyMillis);
+    }
     RpcServer.getCurrentCall().ifPresent(call -> call.updateFsReadTime(latencyMillis));
     if (pread) {
       metrics.updateFsPreadTime(latencyMillis);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -192,12 +192,7 @@ public final class HFile {
     return CHECKSUM_FAILURES.sum();
   }
 
-  public static final void updateReadLatency(long latencyMillis, boolean pread,
-    int slowReadThresholdMs, String hFileName, long offset, int onDiskSizeWithHeader) {
-    if (latencyMillis > slowReadThresholdMs) {
-      LOG.warn("Slow read: hfileName={}, offset={}, size={}, pread={}, durationMillis={}",
-        hFileName, offset, onDiskSizeWithHeader, pread, latencyMillis);
-    }
+  public static void updateReadLatency(long latencyMillis, boolean pread) {
     RpcServer.getCurrentCall().ifPresent(call -> call.updateFsReadTime(latencyMillis));
     if (pread) {
       metrics.updateFsPreadTime(latencyMillis);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hbase.io.MetricsIOWrapperImpl;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext.ReaderType;
+import org.apache.hadoop.hbase.ipc.RpcServer;
 import org.apache.hadoop.hbase.regionserver.CellSink;
 import org.apache.hadoop.hbase.regionserver.ShipperListener;
 import org.apache.hadoop.hbase.util.BloomFilterWriter;
@@ -192,6 +193,7 @@ public final class HFile {
   }
 
   public static final void updateReadLatency(long latencyMillis, boolean pread) {
+    RpcServer.getCurrentCall().ifPresent(call -> call.updateFsReadTime(latencyMillis));
     if (pread) {
       metrics.updateFsPreadTime(latencyMillis);
     } else {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -1212,7 +1212,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
       // Cache Miss, please load.
 
       HFileBlock compressedBlock =
-        fsBlockReader.readBlockData(metaBlockOffset, blockSize, true, false, true);
+        fsBlockReader.readBlockData(metaBlockOffset, blockSize, true, true, true);
       HFileBlock uncompressedBlock = compressedBlock.unpack(hfileContext, fsBlockReader);
       if (compressedBlock != uncompressedBlock) {
         compressedBlock.release();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCall.java
@@ -132,4 +132,8 @@ public interface RpcCall extends RpcCallContext {
 
   /** Returns A short string format of this call without possibly lengthy params */
   String toShortString();
+
+  void updateFsReadTime(long latencyMillis);
+
+  long getFsReadTime();
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
@@ -443,14 +443,16 @@ public abstract class RpcServer implements RpcServerInterface, ConfigurationObse
       int totalTime = (int) (endTime - receiveTime);
       if (LOG.isTraceEnabled()) {
         LOG.trace(
-          "{}, response: {}, receiveTime: {}, queueTime: {}, processingTime: {}, totalTime: {}",
+          "{}, response: {}, receiveTime: {}, queueTime: {}, processingTime: {}, totalTime: {}, fsReadTime: {}",
           CurCall.get().toString(), TextFormat.shortDebugString(result),
-          CurCall.get().getReceiveTime(), qTime, processingTime, totalTime);
+          CurCall.get().getReceiveTime(), qTime, processingTime, totalTime,
+          CurCall.get().getFsReadTime());
       }
       // Use the raw request call size for now.
       long requestSize = call.getSize();
       long responseSize = result.getSerializedSize();
       long responseBlockSize = call.getBlockBytesScanned();
+      long fsReadTime = call.getFsReadTime();
       if (call.isClientCellBlockSupported()) {
         // Include the payload size in HBaseRpcController
         responseSize += call.getResponseCellSize();
@@ -471,13 +473,13 @@ public abstract class RpcServer implements RpcServerInterface, ConfigurationObse
         // note that large responses will often also be slow.
         logResponse(param, md.getName(), md.getName() + "(" + param.getClass().getName() + ")",
           tooLarge, tooSlow, status.getClient(), startTime, processingTime, qTime, responseSize,
-          responseBlockSize, userName);
+          responseBlockSize, fsReadTime, userName);
         if (this.namedQueueRecorder != null && this.isOnlineLogProviderEnabled) {
           // send logs to ring buffer owned by slowLogRecorder
           final String className =
             server == null ? StringUtils.EMPTY : server.getClass().getSimpleName();
           this.namedQueueRecorder.addRecord(new RpcLogDetails(call, param, status.getClient(),
-            responseSize, responseBlockSize, className, tooSlow, tooLarge));
+            responseSize, responseBlockSize, fsReadTime, className, tooSlow, tooLarge));
         }
       }
       return new Pair<>(result, controller.cellScanner());
@@ -521,7 +523,7 @@ public abstract class RpcServer implements RpcServerInterface, ConfigurationObse
    */
   void logResponse(Message param, String methodName, String call, boolean tooLarge, boolean tooSlow,
     String clientAddress, long startTime, int processingTime, int qTime, long responseSize,
-    long blockBytesScanned, String userName) {
+    long blockBytesScanned, long fsReadTime, String userName) {
     final String className = server == null ? StringUtils.EMPTY : server.getClass().getSimpleName();
     // base information that is reported regardless of type of call
     Map<String, Object> responseInfo = new HashMap<>();
@@ -530,6 +532,7 @@ public abstract class RpcServer implements RpcServerInterface, ConfigurationObse
     responseInfo.put("queuetimems", qTime);
     responseInfo.put("responsesize", responseSize);
     responseInfo.put("blockbytesscanned", blockBytesScanned);
+    responseInfo.put("fsreadtime", fsReadTime);
     responseInfo.put("client", clientAddress);
     responseInfo.put("class", className);
     responseInfo.put("method", methodName);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -100,6 +100,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
 
   private long responseCellSize = 0;
   private long responseBlockSize = 0;
+  private long fsReadTimeMillis = 0;
   // cumulative size of serialized exceptions
   private long exceptionSize = 0;
   private final boolean retryImmediatelySupported;
@@ -572,5 +573,15 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
       allowedOnPath = ".*/src/test/.*")
   public synchronized RpcCallback getCallBack() {
     return this.rpcCallback;
+  }
+
+  @Override
+  public void updateFsReadTime(long latencyMillis) {
+    fsReadTimeMillis += latencyMillis;
+  }
+
+  @Override
+  public long getFsReadTime() {
+    return fsReadTimeMillis;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/namequeues/RpcLogDetails.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/namequeues/RpcLogDetails.java
@@ -42,6 +42,7 @@ public class RpcLogDetails extends NamedQueuePayload {
   private final String clientAddress;
   private final long responseSize;
   private final long blockBytesScanned;
+  private final long fsReadTime;
   private final String className;
   private final boolean isSlowLog;
   private final boolean isLargeLog;
@@ -49,12 +50,14 @@ public class RpcLogDetails extends NamedQueuePayload {
   private final Map<String, byte[]> requestAttributes;
 
   public RpcLogDetails(RpcCall rpcCall, Message param, String clientAddress, long responseSize,
-    long blockBytesScanned, String className, boolean isSlowLog, boolean isLargeLog) {
+    long blockBytesScanned, long fsReadTime, String className, boolean isSlowLog,
+    boolean isLargeLog) {
     super(SLOW_LOG_EVENT);
     this.rpcCall = rpcCall;
     this.clientAddress = clientAddress;
     this.responseSize = responseSize;
     this.blockBytesScanned = blockBytesScanned;
+    this.fsReadTime = fsReadTime;
     this.className = className;
     this.isSlowLog = isSlowLog;
     this.isLargeLog = isLargeLog;
@@ -90,6 +93,10 @@ public class RpcLogDetails extends NamedQueuePayload {
 
   public long getBlockBytesScanned() {
     return blockBytesScanned;
+  }
+
+  public long getFsReadTime() {
+    return fsReadTime;
   }
 
   public String getClassName() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/namequeues/impl/SlowLogQueueService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/namequeues/impl/SlowLogQueueService.java
@@ -123,6 +123,7 @@ public class SlowLogQueueService implements NamedQueueService {
     final String clientAddress = rpcLogDetails.getClientAddress();
     final long responseSize = rpcLogDetails.getResponseSize();
     final long blockBytesScanned = rpcLogDetails.getBlockBytesScanned();
+    final long fsReadTime = rpcLogDetails.getFsReadTime();
     final String className = rpcLogDetails.getClassName();
     final TooSlowLog.SlowLogPayload.Type type = getLogType(rpcLogDetails);
     if (type == null) {
@@ -167,7 +168,8 @@ public class SlowLogQueueService implements NamedQueueService {
       .setProcessingTime(processingTime).setQueueTime(qTime)
       .setRegionName(slowLogParams != null ? slowLogParams.getRegionName() : StringUtils.EMPTY)
       .setResponseSize(responseSize).setBlockBytesScanned(blockBytesScanned)
-      .setServerClass(className).setStartTime(startTime).setType(type).setUserName(userName)
+      .setFsReadTime(fsReadTime).setServerClass(className).setStartTime(startTime).setType(type)
+      .setUserName(userName)
       .addAllRequestAttribute(buildNameBytesPairs(rpcLogDetails.getRequestAttributes()))
       .addAllConnectionAttribute(buildNameBytesPairs(rpcLogDetails.getConnectionAttributes()));
     if (slowLogParams != null && slowLogParams.getScan() != null) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -3471,6 +3471,11 @@ public class RSRpcServices
           // from block size progress before writing into the response
           scannerContext.getMetrics().countOfBlockBytesScanned
             .set(scannerContext.getBlockSizeProgress());
+          if (rpcCall != null) {
+            scannerContext.getMetrics().queueTime
+              .set(rpcCall.getStartTime() - rpcCall.getReceiveTime());
+            scannerContext.getMetrics().fsReadTime.set(rpcCall.getFsReadTime());
+          }
           Map<String, Long> metrics = scannerContext.getMetrics().getMetricsMap();
           ScanMetrics.Builder metricBuilder = ScanMetrics.newBuilder();
           NameInt64Pair.Builder pairBuilder = NameInt64Pair.newBuilder();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/LoadIncrementalHFiles.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/LoadIncrementalHFiles.java
@@ -871,7 +871,7 @@ public class LoadIncrementalHFiles extends Configured implements Tool {
     List<LoadQueueItem> toRetry = new ArrayList<>();
     try {
       Configuration conf = getConf();
-      byte[] region = RpcRetryingCallerFactory.instantiate(conf, null, null).<byte[]> newCaller()
+      byte[] region = RpcRetryingCallerFactory.instantiate(conf, null).<byte[]> newCaller()
         .callWithRetries(serviceCallable, Integer.MAX_VALUE);
       if (region == null) {
         LOG.warn("Attempt to bulk load region containing " + Bytes.toStringBinary(first)

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/HConnectionTestingUtility.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/HConnectionTestingUtility.java
@@ -127,8 +127,8 @@ public class HConnectionTestingUtility {
       RpcRetryingCallerFactory.instantiate(conf, c.getConnectionMetrics()),
       RpcControllerFactory.instantiate(conf));
     Mockito.when(c.getAsyncProcess()).thenReturn(asyncProcess);
-    Mockito.when(c.getNewRpcRetryingCallerFactory(conf)).thenReturn(RpcRetryingCallerFactory
-      .instantiate(conf, RetryingCallerInterceptorFactory.NO_OP_INTERCEPTOR, null, null));
+    Mockito.when(c.getNewRpcRetryingCallerFactory(conf))
+      .thenReturn(RpcRetryingCallerFactory.instantiate(conf, null, null));
     Mockito.when(c.getRpcControllerFactory()).thenReturn(Mockito.mock(RpcControllerFactory.class));
     Table t = Mockito.mock(Table.class);
     Mockito.when(c.getTable((TableName) Mockito.any())).thenReturn(t);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
@@ -667,13 +667,13 @@ public class TestNamedQueueRecorder {
   static RpcLogDetails getRpcLogDetails(String userName, String clientAddress, String className,
     int forcedParamIndex) {
     RpcCall rpcCall = getRpcCall(userName, forcedParamIndex);
-    return new RpcLogDetails(rpcCall, rpcCall.getParam(), clientAddress, 0, 0, className, true,
+    return new RpcLogDetails(rpcCall, rpcCall.getParam(), clientAddress, 0, 0, 0, className, true,
       true);
   }
 
   static RpcLogDetails getRpcLogDetails(String userName, String clientAddress, String className) {
     RpcCall rpcCall = getRpcCall(userName);
-    return new RpcLogDetails(rpcCall, rpcCall.getParam(), clientAddress, 0, 0, className, true,
+    return new RpcLogDetails(rpcCall, rpcCall.getParam(), clientAddress, 0, 0, 0, className, true,
       true);
   }
 
@@ -685,8 +685,8 @@ public class TestNamedQueueRecorder {
   private RpcLogDetails getRpcLogDetails(String userName, String clientAddress, String className,
     boolean isSlowLog, boolean isLargeLog) {
     RpcCall rpcCall = getRpcCall(userName);
-    return new RpcLogDetails(rpcCall, rpcCall.getParam(), clientAddress, 0, 0, className, isSlowLog,
-      isLargeLog);
+    return new RpcLogDetails(rpcCall, rpcCall.getParam(), clientAddress, 0, 0, 0, className,
+      isSlowLog, isLargeLog);
   }
 
   private static RpcCall getRpcCall(String userName) {
@@ -858,6 +858,15 @@ public class TestNamedQueueRecorder {
 
       @Override
       public void incrementResponseExceptionSize(long exceptionSize) {
+      }
+
+      @Override
+      public void updateFsReadTime(long latencyMillis) {
+      }
+
+      @Override
+      public long getFsReadTime() {
+        return 0;
       }
     };
     return rpcCall;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
@@ -80,7 +80,7 @@ public class TestRpcLogDetails {
     ProtobufUtil.mergeFrom(messageBuilder, cis, buffer.capacity());
     Message message = messageBuilder.build();
     RpcLogDetails rpcLogDetails =
-      new RpcLogDetails(getRpcCall(message), message, null, 0L, 0L, null, true, false);
+      new RpcLogDetails(getRpcCall(message), message, null, 0L, 0L, 0, null, true, false);
 
     // log's scan should be equal
     ClientProtos.Scan logScan = ((ClientProtos.ScanRequest) rpcLogDetails.getParam()).getScan();
@@ -257,6 +257,15 @@ public class TestRpcLogDetails {
 
       @Override
       public void incrementResponseExceptionSize(long exceptionSize) {
+      }
+
+      @Override
+      public void updateFsReadTime(long latencyMillis) {
+      }
+
+      @Override
+      public long getFsReadTime() {
+        return 0;
       }
     };
     return rpcCall;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
@@ -320,6 +320,16 @@ public class TestRegionProcedureStore extends RegionProcedureStoreTestBase {
       @Override
       public void incrementResponseExceptionSize(long exceptionSize) {
       }
+
+      @Override
+      public void updateFsReadTime(long latencyMillis) {
+      }
+
+      @Override
+      public long getFsReadTime() {
+        return 0;
+      }
+
     };
   }
 }


### PR DESCRIPTION
Adds the following:

1. queueTime, throttleTime, and fsReadTime to ScanMetrics. Hopefully these can help us focus in on where the problem is for these long scans.
2. fsReadTime to the slow log
3. Adds a new configurable hfile.slow.read.threshold.ms. When an fs read takes longer than this, we will log a warning and increment a counter.

I added tests for the ScanMetrics stuff. There aren't really tests for slow log, so didn't add that. The new config doesn't seem necessary to test.

I manually ran a bunch of extra tests locally as well since we aren't getting the full pre-commit hook. They all looked good.