### PR TITLE
Remove relocations and hack, as this was handled in mapreduce.job.classloader.system.classes now

### DIFF
--- a/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/io/MetricsIOSourceImpl.java
+++ b/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/io/MetricsIOSourceImpl.java
@@ -51,12 +51,7 @@ public class MetricsIOSourceImpl extends BaseSourceImpl implements MetricsIOSour
       getMetricsRegistry().newTimeHistogram(FS_PREAD_TIME_HISTO_KEY, FS_PREAD_TIME_HISTO_DESC);
     fsWriteTimeHisto =
       getMetricsRegistry().newTimeHistogram(FS_WRITE_HISTO_KEY, FS_WRITE_TIME_HISTO_DESC);
-    // The below usage of Interns is not standard. It's used to get around some illegal access issues
-    // due to the shading we do in our client bundle. Usually a call to newCounter will directly
-    // instantiate MetricsInfoImpl, but we relocate DynamicMetricsRegistry such that it throws
-    // illegal access due to MetricsInfoImpl being package private. Interns is public and not relocated,
-    // so can get around that. We will need to ideally find a better way.
-    fsSlowReads = getMetricsRegistry().newCounter(Interns.info(SLOW_FS_READS_KEY, SLOW_FS_READS_DESC), 0L);
+    fsSlowReads = getMetricsRegistry().newCounter(SLOW_FS_READS_KEY, SLOW_FS_READS_DESC, 0L);
   }
 
   @Override

--- a/hubspot-client-bundles/pom.xml
+++ b/hubspot-client-bundles/pom.xml
@@ -85,40 +85,6 @@
                     <pattern>com.codahale.metrics</pattern>
                     <shadedPattern>${shade.prefix}.com.codahale.metrics</shadedPattern>
                   </relocation>
-                  <!--
-                    This is a little brittle, but as far as I can tell this class list hasn't
-                    really changed much. The core problem this solves is that our hadoop jobs
-                    are executed with mapreduce.job.classloader.system.classes set, including
-                    org.apache.hadoop. As a result trying to load any of these classes will
-                    throw ClassNotFoundException because they aren't actually system classes
-                    but are covered by that property. Another option would be to exclude
-                    org.apache.hadoop.metrics2 from the system classes list, but there are a
-                    bunch of classes in there in hadoop and it's hard to know the implications
-                    of that. So I decided to solve this for hbase by shading these classes
-                    which are brought in by hbase-hadoop-compat and hbase-hadoop2-compat.
-                    These classes are used in snapshot scan jobs, because the metrics are
-                    initialized when opening an HFile for read.
-                  -->
-                  <relocation>
-                    <pattern>org.apache.hadoop.metrics2</pattern>
-                    <shadedPattern>${shade.prefix}.org.apache.hadoop.metrics2</shadedPattern>
-                    <includes>
-                      <include>org.apache.hadoop.metrics2.MetricHistogram</include>
-                      <include>org.apache.hadoop.metrics2.MetricsExecutor</include>
-                      <include>org.apache.hadoop.metrics2.impl.JmxCacheBuster*</include>
-                      <include>org.apache.hadoop.metrics2.lib.DefaultMetricsSystemHelper</include>
-                      <include>org.apache.hadoop.metrics2.lib.DynamicMetricsRegistry</include>
-                      <include>org.apache.hadoop.metrics2.lib.MetricsExecutorImpl</include>
-                      <include>org.apache.hadoop.metrics2.lib.MetricsExecutorImpl*</include>
-                      <include>org.apache.hadoop.metrics2.lib.MutableFastCounter</include>
-                      <include>org.apache.hadoop.metrics2.lib.MutableHistogram</include>
-                      <include>org.apache.hadoop.metrics2.lib.MutableRangeHistogram</include>
-                      <include>org.apache.hadoop.metrics2.lib.MutableSizeHistogram</include>
-                      <include>org.apache.hadoop.metrics2.lib.MutableTimeHistogram</include>
-                      <include>org.apache.hadoop.metrics2.util.MetricQuantile</include>
-                      <include>org.apache.hadoop.metrics2.util.MetricSampleQuantiles*</include>
-                    </includes>
-                  </relocation>
                 </relocations>
                 <filters>
                   <filter>


### PR DESCRIPTION
As the comments in the removed code describe, we initially had issue with ClassNotFoundExceptions in hadoop. This was due to `mapreduce.job.classloader.system.classes` treating all `org.apache.hadoop.` and subpackage classes as "system classes". System classes are loaded from a special application loader which does not include user jars/classes. Since we don't have hbase installed on yarn, these classes were not found on the special classpath. So I shaded the hbase-provided metrics classes to avoid them being considered system classes.

This worked for a while because really the only exposure on the client side was from MetricsIOSourceImpl and it only exposed two metrics which were time histograms. Those newTimeHistogram methods dont use any hadoop metric classes. 

Recently, we added a new counter to this class. Counters like this are common in hbase, but just happen to not have been used in this metric class yet. When this was added, we started seeing IllegalAccessExceptions. It turns out this is because `newCounter` tries to construct a MetricsInfoImpl which comes from hadoop and is package private. This is why hbase's metric classes are in the metrics package, so that they can hook into internals there. Since we are shading the hbase provided classes, they no longer can call a package private constructor.

For some reason I did not consider an alternative when I first added these relocations -- just add the hbase classes as exclusions in `mapreduce.job.classloader.system.classes`. I've done that now and tested that everything works as expected. So now we can remove these hacks.