### PR TITLE
Hubspot backport (sorta): Expose client TLS certificate on RpcCallContext

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.net.InetAddress;
+import java.security.cert.X509Certificate;
 import java.util.Optional;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -59,6 +60,13 @@ public interface RpcCallContext {
   default Optional<String> getRequestUserName() {
     return getRequestUser().map(User::getShortName);
   }
+
+  /**
+   * Returns the TLS certificate that the client presented to this HBase server when making its
+   * connection. TLS is orthogonal to Kerberos, so this is unrelated to
+   * {@link this#getRequestUser()}. Both, one, or neither, may be present.
+   */
+  Optional<X509Certificate> getClientCertificate();
 
   /** Returns Address of remote client in this call */
   InetAddress getRemoteAddress();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -24,6 +24,7 @@ import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -96,6 +97,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
 
   protected final User user;
   protected final InetAddress remoteAddress;
+  protected final X509Certificate clientCertificate;
   protected RpcCallback rpcCallback;
 
   private long responseCellSize = 0;
@@ -136,9 +138,11 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
     if (connection != null) {
       this.user = connection.user;
       this.retryImmediatelySupported = connection.retryImmediatelySupported;
+      this.clientCertificate = connection.clientCertificate;
     } else {
       this.user = null;
       this.retryImmediatelySupported = false;
+      this.clientCertificate = null;
     }
     this.remoteAddress = remoteAddress;
     this.timeout = timeout;
@@ -497,6 +501,11 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   @Override
   public Optional<User> getRequestUser() {
     return Optional.ofNullable(user);
+  }
+
+  @Override
+  public Optional<X509Certificate> getClientCertificate() {
+    return Optional.ofNullable(clientCertificate);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
@@ -31,6 +31,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -133,6 +134,8 @@ abstract class ServerRpcConnection implements Closeable {
   protected User user = null;
   protected UserGroupInformation ugi = null;
   protected SaslServerAuthenticationProviders saslProviders = null;
+  // volatile because this gets set after this object is constructed, when TLS handshake finishes
+  protected volatile X509Certificate clientCertificate = null;
 
   public ServerRpcConnection(RpcServer rpcServer) {
     this.rpcServer = rpcServer;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -812,6 +813,11 @@ public class TestNamedQueueRecorder {
       @Override
       public Optional<User> getRequestUser() {
         return getUser(userName);
+      }
+
+      @Override
+      public Optional<X509Certificate> getClientCertificate() {
+        return Optional.empty();
       }
 
       @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -211,6 +212,11 @@ public class TestRpcLogDetails {
       @Override
       public Optional<User> getRequestUser() {
         return null;
+      }
+
+      @Override
+      public Optional<X509Certificate> getClientCertificate() {
+        return Optional.empty();
       }
 
       @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -272,6 +273,11 @@ public class TestRegionProcedureStore extends RegionProcedureStoreTestBase {
 
       @Override
       public Optional<User> getRequestUser() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<X509Certificate> getClientCertificate() {
         return Optional.empty();
       }
 


### PR DESCRIPTION
To test the performance of https://git.hubteam.com/HubSpot/HubSpotCoprocessors/pull/227, I need supporting changes in HBase. I think it makes sense to put these changes into hubspot-2.5 now so I can test the coprocessor. If that goes well, the changes will be ready for branch-2.6 upstream. If not, we'll rethink and avoid merging something upstream that we end up not needing.