### PR TITLE
HubSpot backport: finalized copy of: HBASE-28317 Expose client TLS certificate on RpcCallContext (#5644)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
@@ -62,11 +62,11 @@ public interface RpcCallContext {
   }
 
   /**
-   * Returns the TLS certificate that the client presented to this HBase server when making its
+   * Returns the TLS certificate(s) that the client presented to this HBase server when making its
    * connection. TLS is orthogonal to Kerberos, so this is unrelated to
-   * {@link this#getRequestUser()}. Both, one, or neither, may be present.
+   * {@link RpcCallContext#getRequestUser()}. Both, one, or neither may be present.
    */
-  Optional<X509Certificate> getClientCertificate();
+  Optional<X509Certificate[]> getClientCertificateChain();
 
   /** Returns Address of remote client in this call */
   InetAddress getRemoteAddress();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -97,7 +97,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
 
   protected final User user;
   protected final InetAddress remoteAddress;
-  protected final X509Certificate clientCertificate;
+  protected final X509Certificate[] clientCertificateChain;
   protected RpcCallback rpcCallback;
 
   private long responseCellSize = 0;
@@ -138,11 +138,11 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
     if (connection != null) {
       this.user = connection.user;
       this.retryImmediatelySupported = connection.retryImmediatelySupported;
-      this.clientCertificate = connection.clientCertificate;
+      this.clientCertificateChain = connection.clientCertificateChain;
     } else {
       this.user = null;
       this.retryImmediatelySupported = false;
-      this.clientCertificate = null;
+      this.clientCertificateChain = null;
     }
     this.remoteAddress = remoteAddress;
     this.timeout = timeout;
@@ -504,8 +504,8 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   }
 
   @Override
-  public Optional<X509Certificate> getClientCertificate() {
-    return Optional.ofNullable(clientCertificate);
+  public Optional<X509Certificate[]> getClientCertificateChain() {
+    return Optional.ofNullable(clientCertificateChain);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
@@ -134,8 +134,7 @@ abstract class ServerRpcConnection implements Closeable {
   protected User user = null;
   protected UserGroupInformation ugi = null;
   protected SaslServerAuthenticationProviders saslProviders = null;
-  // volatile because this gets set after this object is constructed, when TLS handshake finishes
-  protected volatile X509Certificate clientCertificate = null;
+  protected X509Certificate[] clientCertificateChain = null;
 
   public ServerRpcConnection(RpcServer rpcServer) {
     this.rpcServer = rpcServer;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
@@ -816,7 +816,7 @@ public class TestNamedQueueRecorder {
       }
 
       @Override
-      public Optional<X509Certificate> getClientCertificate() {
+      public Optional<X509Certificate[]> getClientCertificateChain() {
         return Optional.empty();
       }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
@@ -215,7 +215,7 @@ public class TestRpcLogDetails {
       }
 
       @Override
-      public Optional<X509Certificate> getClientCertificate() {
+      public Optional<X509Certificate[]> getClientCertificateChain() {
         return Optional.empty();
       }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
@@ -277,7 +277,7 @@ public class TestRegionProcedureStore extends RegionProcedureStoreTestBase {
       }
 
       @Override
-      public Optional<X509Certificate> getClientCertificate() {
+      public Optional<X509Certificate[]> getClientCertificateChain() {
         return Optional.empty();
       }
 


### PR DESCRIPTION
An earlier iteration of my upstream changes were already placed on hubspot-2.5, now this brings it up to speed with the final version of https://github.com/apache/hbase/pull/5644