### PR TITLE
Fix build

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -4,7 +4,7 @@ buildpack:
 env:
   MAVEN_PHASE: "package assembly:single deploy"
   HADOOP_DEP_VERSION: "3.3.6-hubspot-SNAPSHOT"
-  MAVEN_ARGS: "-Phadoop-3.0 -Dhadoop.profile=3.0 -Dhadoop-three.version=$HADOOP_DEP_VERSION -Dgpg.skip=true -DskipTests -DdeployAtEnd -pl hbase-assembly -am"
+  MAVEN_BUILD_ARGS: "-Phadoop-3.0 -Dhadoop.profile=3.0 -Dhadoop-three.version=$HADOOP_DEP_VERSION -Dgpg.skip=true -DskipTests -DdeployAtEnd -pl hbase-assembly -am"
 
   # Below variables are generated in prepare_environment.sh.
   # The build environment requires environment variables to be explicitly defined before they may

--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -89,9 +89,9 @@ write-build-env-var YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8 "$YUM_REPO_UPLOAD_OVERRIDE
 # with 2.6-hubspot-SNAPSHOT which is not very useful as a point of reference.
 # Another option would be to pass in our FULL_BUILD_VERSION but that might cause some funniness
 # with the expectations in VersionInfo.compareVersion().
-write-build-env-var MAVEN_ARGS "$MAVEN_ARGS -Dversioninfo.version=$HBASE_VERSION"
+write-build-env-var MAVEN_BUILD_ARGS "$MAVEN_BUILD_ARGS -Dversioninfo.version=$HBASE_VERSION"
 
 echo "Building HBase version $HBASE_VERSION"
 echo "Will deploy to nexus with version $SET_VERSION"
 echo "Will create rpm with version $FULL_BUILD_VERSION"
-echo "Will run maven with extra args $MAVEN_ARGS"
+echo "Will run maven with extra args $MAVEN_BUILD_ARGS"

--- a/hbase-rpm/.blazar.yaml
+++ b/hbase-rpm/.blazar.yaml
@@ -14,7 +14,7 @@ env:
   HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
-  MAVEN_ARGS: ""
+  MAVEN_BUILD_ARGS: ""
 
 depends:
   - hbase

--- a/hubspot-client-bundles/.blazar.yaml
+++ b/hubspot-client-bundles/.blazar.yaml
@@ -11,7 +11,7 @@ env:
   HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
-  MAVEN_ARGS: ""
+  MAVEN_BUILD_ARGS: ""
 
 before:
   - description: "Prepare build environment"

--- a/hubspot-client-bundles/hbase-backup-restore-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-backup-restore-bundle/.blazar.yaml
@@ -11,7 +11,7 @@ env:
   HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
-  MAVEN_ARGS: ""
+  MAVEN_BUILD_ARGS: ""
 
 before:
   - description: "Prepare build environment"

--- a/hubspot-client-bundles/hbase-client-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-client-bundle/.blazar.yaml
@@ -11,7 +11,7 @@ env:
   HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
-  MAVEN_ARGS: ""
+  MAVEN_BUILD_ARGS: ""
 
 before:
   - description: "Prepare build environment"

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/.blazar.yaml
@@ -11,7 +11,7 @@ env:
   HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
-  MAVEN_ARGS: ""
+  MAVEN_BUILD_ARGS: ""
 
 before:
   - description: "Prepare build environment"

--- a/hubspot-client-bundles/pom.xml
+++ b/hubspot-client-bundles/pom.xml
@@ -20,6 +20,8 @@
     unexpected netty dependencies. This is problematic with the shade plugin because it flattens
     the dependency tree, so those dependencies become direct dependencies of the bundle. -->
     <zookeeper.version>3.6.3-shaded-SNAPSHOT</zookeeper.version>
+
+    <revision>2.5-hubspot-SNAPSHOT</revision>
   </properties>
 
   <dependencyManagement>
@@ -56,6 +58,11 @@
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-shaded-netty-tcnative</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-compression-zstd</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
We have to start using MAVEN_BUILD_ARGS.

Also, I was wrong @charlesconnell, you were right to include the version for compression-zstd. It used to be that it wasn't necessary, but in the recent build refactors I changed the bundles so they no longer inherit from the hbase parent pom. This was done to insulate us from some profile nonsense in the hbase pom, but has the side-effect that we no longer inherit the versions for modules we pull in.