### PR TITLE
Add an hbase-site.xml to our bundles that configures ZStdCodec

### DIFF
--- a/hubspot-client-bundles/hbase-mapreduce-bundle/src/main/resources/hbase-site.xml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/src/main/resources/hbase-site.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <!-- HBase clients that wish to read zstd HFiles must use the
+         same codec that wrote them on the RegionServers -->
+    <name>hbase.io.compress.zstd.codec</name>
+    <value>org.apache.hadoop.hbase.io.compress.zstd.ZstdCodec</value>
+  </property>
+</configuration>

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/src/main/resources/hbase-site.xml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/src/main/resources/hbase-site.xml
@@ -3,7 +3,9 @@
 <configuration>
   <property>
     <!-- HBase clients that wish to read zstd HFiles must use the
-         same codec that wrote them on the RegionServers -->
+         same codec that wrote them on the RegionServers.
+         Compression.java reads its codec choice from HBaseConfiguration.create(),
+         so this setting must be supplied on the classpath, not programmatically. -->
     <name>hbase.io.compress.zstd.codec</name>
     <value>org.apache.hadoop.hbase.io.compress.zstd.ZstdCodec</value>
   </property>


### PR DESCRIPTION
This works at including the file in the mapreduce bundle, but not at carrying it into the backup-restore bundle. I can't figure out the right incantation for IncludeResourceTransformer. Do you know @bbeaudreault ?