### PR TITLE
Relocate commons-io

### DIFF
--- a/hubspot-client-bundles/hbase-client-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-client-bundle/pom.xml
@@ -98,6 +98,8 @@
                   <include>com.google.protobuf:protobuf-java</include>
                   <!--  For client metrics we need to include so the metrics package can be shaded to prevent issues with our parent pom -->
                   <include>io.dropwizard.metrics:metrics-core</include>
+                  <!-- conflicts with hubspot managed version, so include it with shading -->
+                  <include>commons-io:commons-io</include>
                 </includes>
               </artifactSet>
               <filters>

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
@@ -15,6 +15,13 @@
     <dependency>
       <groupId>com.hubspot.hbase</groupId>
       <artifactId>hbase-client-bundle</artifactId>
+      <exclusions>
+        <!-- we bundle commons-io, but it also come through transitively. -->
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
@@ -74,6 +74,11 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <!-- this one is included in the client bundle, shaded -->
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.sun.jersey</groupId>
           <artifactId>*</artifactId>
@@ -150,6 +155,11 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <!-- this one is included in the client bundle, shaded -->
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>javax.servlet.jsp</groupId>
           <artifactId>*</artifactId>
@@ -191,6 +201,11 @@
         <exclusion>
           <groupId>org.apache.hbase</groupId>
           <artifactId>*</artifactId>
+        </exclusion>
+        <!-- this one is included in the client bundle, shaded -->
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/hubspot-client-bundles/pom.xml
+++ b/hubspot-client-bundles/pom.xml
@@ -381,6 +381,10 @@
                     <pattern>com.codahale.metrics</pattern>
                     <shadedPattern>${shade.prefix}.com.codahale.metrics</shadedPattern>
                   </relocation>
+                  <relocation>
+                    <pattern>org.apache.commons.io</pattern>
+                    <shadedPattern>${shade.prefix}.org.apache.commons.io</shadedPattern>
+                  </relocation>
                 </relocations>
                 <filters>
                   <filter>


### PR DESCRIPTION
Periodically we see issue with IOUtils.closeQuietly, because the version of commons-io in hbase conflicts with the one pinned by parent-pom in hubspot. This shades and relocates commons-io so that we don't conflict anymore.