### PR TITLE
Hubspot backport: HBASE-27672 Read RPC threads may BLOCKED at the Configuration.get when using java compression

### DIFF
--- a/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/Lz4Codec.java
+++ b/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/Lz4Codec.java
@@ -46,9 +46,11 @@ public class Lz4Codec implements Configurable, CompressionCodec {
   public static final String LZ4_BUFFER_SIZE_KEY = "hbase.io.compress.lz4.buffersize";
 
   private Configuration conf;
+  private int bufferSize;
 
   public Lz4Codec() {
     conf = new Configuration();
+    bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -59,6 +61,7 @@ public class Lz4Codec implements Configurable, CompressionCodec {
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
+    this.bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -79,7 +82,7 @@ public class Lz4Codec implements Configurable, CompressionCodec {
   @Override
   public CompressionInputStream createInputStream(InputStream in, Decompressor d)
     throws IOException {
-    return new BlockDecompressorStream(in, d, getBufferSize(conf));
+    return new BlockDecompressorStream(in, d, bufferSize);
   }
 
   @Override
@@ -90,7 +93,6 @@ public class Lz4Codec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out, Compressor c)
     throws IOException {
-    int bufferSize = getBufferSize(conf);
     return new BlockCompressorStream(out, c, bufferSize,
       CompressionUtil.compressionOverhead(bufferSize));
   }

--- a/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/LzoCodec.java
+++ b/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/LzoCodec.java
@@ -46,9 +46,11 @@ public class LzoCodec implements Configurable, CompressionCodec {
   public static final String LZO_BUFFER_SIZE_KEY = "hbase.io.compress.lzo.buffersize";
 
   private Configuration conf;
+  private int bufferSize;
 
   public LzoCodec() {
     conf = new Configuration();
+    bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -59,6 +61,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
+    this.bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -79,7 +82,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionInputStream createInputStream(InputStream in, Decompressor d)
     throws IOException {
-    return new BlockDecompressorStream(in, d, getBufferSize(conf));
+    return new BlockDecompressorStream(in, d, bufferSize);
   }
 
   @Override
@@ -90,7 +93,6 @@ public class LzoCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out, Compressor c)
     throws IOException {
-    int bufferSize = getBufferSize(conf);
     return new BlockCompressorStream(out, c, bufferSize,
       CompressionUtil.compressionOverhead(bufferSize));
   }

--- a/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/SnappyCodec.java
+++ b/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/SnappyCodec.java
@@ -46,9 +46,11 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   public static final String SNAPPY_BUFFER_SIZE_KEY = "hbase.io.compress.snappy.buffersize";
 
   private Configuration conf;
+  private int bufferSize;
 
   public SnappyCodec() {
     conf = new Configuration();
+    bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -59,6 +61,7 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
+    this.bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -79,7 +82,7 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionInputStream createInputStream(InputStream in, Decompressor d)
     throws IOException {
-    return new BlockDecompressorStream(in, d, getBufferSize(conf));
+    return new BlockDecompressorStream(in, d, bufferSize);
   }
 
   @Override
@@ -90,7 +93,6 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out, Compressor c)
     throws IOException {
-    int bufferSize = getBufferSize(conf);
     return new BlockCompressorStream(out, c, bufferSize,
       CompressionUtil.compressionOverhead(bufferSize));
   }

--- a/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/ZstdCodec.java
+++ b/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/ZstdCodec.java
@@ -54,14 +54,17 @@ public class ZstdCodec implements Configurable, CompressionCodec {
   public static final int ZSTD_BUFFER_SIZE_DEFAULT = 256 * 1024;
 
   private Configuration conf;
+  private int bufferSize;
 
   public ZstdCodec() {
     conf = new Configuration();
+    bufferSize = getBufferSize(conf);
   }
 
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
+    this.bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -87,7 +90,7 @@ public class ZstdCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionInputStream createInputStream(InputStream in, Decompressor d)
     throws IOException {
-    return new BlockDecompressorStream(in, d, getBufferSize(conf));
+    return new BlockDecompressorStream(in, d, bufferSize);
   }
 
   @Override
@@ -98,7 +101,6 @@ public class ZstdCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out, Compressor c)
     throws IOException {
-    int bufferSize = getBufferSize(conf);
     return new BlockCompressorStream(out, c, bufferSize,
       CompressionUtil.compressionOverhead(bufferSize));
   }

--- a/hbase-compression/hbase-compression-brotli/src/main/java/org/apache/hadoop/hbase/io/compress/brotli/BrotliCodec.java
+++ b/hbase-compression/hbase-compression-brotli/src/main/java/org/apache/hadoop/hbase/io/compress/brotli/BrotliCodec.java
@@ -47,9 +47,15 @@ public class BrotliCodec implements Configurable, CompressionCodec {
   public static final int BROTLI_BUFFERSIZE_DEFAULT = 256 * 1024;
 
   private Configuration conf;
+  private int bufferSize;
+  private int level;
+  private int window;
 
   public BrotliCodec() {
     conf = new Configuration();
+    bufferSize = getBufferSize(conf);
+    level = getLevel(conf);
+    window = getWindow(conf);
   }
 
   @Override
@@ -60,16 +66,19 @@ public class BrotliCodec implements Configurable, CompressionCodec {
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
+    this.bufferSize = getBufferSize(conf);
+    this.level = getLevel(conf);
+    this.window = getWindow(conf);
   }
 
   @Override
   public Compressor createCompressor() {
-    return new BrotliCompressor(getLevel(conf), getWindow(conf), getBufferSize(conf));
+    return new BrotliCompressor(level, window, bufferSize);
   }
 
   @Override
   public Decompressor createDecompressor() {
-    return new BrotliDecompressor(getBufferSize(conf));
+    return new BrotliDecompressor(bufferSize);
   }
 
   @Override
@@ -80,7 +89,7 @@ public class BrotliCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionInputStream createInputStream(InputStream in, Decompressor d)
     throws IOException {
-    return new BlockDecompressorStream(in, d, getBufferSize(conf));
+    return new BlockDecompressorStream(in, d, bufferSize);
   }
 
   @Override
@@ -91,7 +100,6 @@ public class BrotliCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out, Compressor c)
     throws IOException {
-    int bufferSize = getBufferSize(conf);
     return new BlockCompressorStream(out, c, bufferSize,
       CompressionUtil.compressionOverhead(bufferSize));
   }

--- a/hbase-compression/hbase-compression-lz4/src/main/java/org/apache/hadoop/hbase/io/compress/lz4/Lz4Codec.java
+++ b/hbase-compression/hbase-compression-lz4/src/main/java/org/apache/hadoop/hbase/io/compress/lz4/Lz4Codec.java
@@ -44,9 +44,11 @@ public class Lz4Codec implements Configurable, CompressionCodec {
   public static final String LZ4_BUFFER_SIZE_KEY = "hbase.io.compress.lz4.buffersize";
 
   private Configuration conf;
+  private int bufferSize;
 
   public Lz4Codec() {
     conf = new Configuration();
+    this.bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -57,16 +59,17 @@ public class Lz4Codec implements Configurable, CompressionCodec {
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
+    this.bufferSize = getBufferSize(conf);
   }
 
   @Override
   public Compressor createCompressor() {
-    return new Lz4Compressor(getBufferSize(conf));
+    return new Lz4Compressor(bufferSize);
   }
 
   @Override
   public Decompressor createDecompressor() {
-    return new Lz4Decompressor(getBufferSize(conf));
+    return new Lz4Decompressor(bufferSize);
   }
 
   @Override
@@ -77,7 +80,7 @@ public class Lz4Codec implements Configurable, CompressionCodec {
   @Override
   public CompressionInputStream createInputStream(InputStream in, Decompressor d)
     throws IOException {
-    return new BlockDecompressorStream(in, d, getBufferSize(conf));
+    return new BlockDecompressorStream(in, d, bufferSize);
   }
 
   @Override
@@ -88,7 +91,6 @@ public class Lz4Codec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out, Compressor c)
     throws IOException {
-    int bufferSize = getBufferSize(conf);
     return new BlockCompressorStream(out, c, bufferSize,
       CompressionUtil.compressionOverhead(bufferSize));
   }

--- a/hbase-compression/hbase-compression-snappy/src/main/java/org/apache/hadoop/hbase/io/compress/xerial/SnappyCodec.java
+++ b/hbase-compression/hbase-compression-snappy/src/main/java/org/apache/hadoop/hbase/io/compress/xerial/SnappyCodec.java
@@ -44,9 +44,11 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   public static final String SNAPPY_BUFFER_SIZE_KEY = "hbase.io.compress.snappy.buffersize";
 
   private Configuration conf;
+  private int bufferSize;
 
   public SnappyCodec() {
     conf = new Configuration();
+    bufferSize = getBufferSize(conf);
   }
 
   @Override
@@ -57,16 +59,17 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
+    this.bufferSize = getBufferSize(conf);
   }
 
   @Override
   public Compressor createCompressor() {
-    return new SnappyCompressor(getBufferSize(conf));
+    return new SnappyCompressor(bufferSize);
   }
 
   @Override
   public Decompressor createDecompressor() {
-    return new SnappyDecompressor(getBufferSize(conf));
+    return new SnappyDecompressor(bufferSize);
   }
 
   @Override
@@ -77,7 +80,7 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionInputStream createInputStream(InputStream in, Decompressor d)
     throws IOException {
-    return new BlockDecompressorStream(in, d, getBufferSize(conf));
+    return new BlockDecompressorStream(in, d, bufferSize);
   }
 
   @Override
@@ -88,7 +91,6 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out, Compressor c)
     throws IOException {
-    int bufferSize = getBufferSize(conf);
     return new BlockCompressorStream(out, c, bufferSize,
       Snappy.maxCompressedLength(bufferSize) - bufferSize); // overhead only
   }

--- a/hbase-compression/hbase-compression-xz/src/main/java/org/apache/hadoop/hbase/io/compress/xz/LzmaCodec.java
+++ b/hbase-compression/hbase-compression-xz/src/main/java/org/apache/hadoop/hbase/io/compress/xz/LzmaCodec.java
@@ -44,9 +44,13 @@ public class LzmaCodec implements Configurable, CompressionCodec {
   public static final int LZMA_BUFFERSIZE_DEFAULT = 256 * 1024;
 
   private Configuration conf;
+  private int bufferSize;
+  private int level;
 
   public LzmaCodec() {
     conf = new Configuration();
+    bufferSize = getBufferSize(conf);
+    level = getLevel(conf);
   }
 
   @Override
@@ -57,16 +61,18 @@ public class LzmaCodec implements Configurable, CompressionCodec {
   @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
+    this.bufferSize = getBufferSize(conf);
+    this.level = getLevel(conf);
   }
 
   @Override
   public Compressor createCompressor() {
-    return new LzmaCompressor(getLevel(conf), getBufferSize(conf));
+    return new LzmaCompressor(level, bufferSize);
   }
 
   @Override
   public Decompressor createDecompressor() {
-    return new LzmaDecompressor(getBufferSize(conf));
+    return new LzmaDecompressor(bufferSize);
   }
 
   @Override
@@ -77,7 +83,7 @@ public class LzmaCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionInputStream createInputStream(InputStream in, Decompressor d)
     throws IOException {
-    return new BlockDecompressorStream(in, d, getBufferSize(conf));
+    return new BlockDecompressorStream(in, d, bufferSize);
   }
 
   @Override
@@ -88,7 +94,6 @@ public class LzmaCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream out, Compressor c)
     throws IOException {
-    int bufferSize = getBufferSize(conf);
     return new BlockCompressorStream(out, c, bufferSize,
       CompressionUtil.compressionOverhead(bufferSize));
   }


### PR DESCRIPTION
This is a nice addition to our switches to zstd, because it further improves compression/decompression speed.