### PR TITLE
Fix backport of AVOID_LOCAL_WRITES

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
@@ -758,10 +758,10 @@ public final class CommonFSUtils {
       Method noLocalWriteMethod = null;
       if (builderClass != null) {
         try {
-          replicateMethod = builderClass.getMethod("noLocalWrite");
+          noLocalWriteMethod = builderClass.getMethod("noLocalWrite");
           LOG.debug("Using builder API via reflection for DFS file creation.");
         } catch (NoSuchMethodException e) {
-          LOG.debug("Could not find noLocalWrite method on builder; will not set replicate when"
+          LOG.debug("Could not find noLocalWrite method on builder; will not set noLocalWrite when"
             + " creating output stream", e);
         }
       }


### PR DESCRIPTION
The WAL requires non-EC. The builder we use for creating the WAL output stream calls `builder.replicate()` which basically overrides any EC policy with default replication as a precaution. There was a copy/paste error in the backport of this feature to our fork, which accidentally overrides the the `replicateMethod` with a reflection of the `noLocalWrite` method. So when we go to call `replicate()` to ensure non-EC, we're actually calling `noLocalWrite()`.

This bug is not present in the upstream backports, but this time the hubspot backport was done separately. Here I fix the copy/paste so we don't override the replicateMethod.