### PR TITLE
Build into AnyLinuxVersion repos for future-proofing

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -10,8 +10,7 @@ env:
   # The build environment requires environment variables to be explicitly defined before they may
   # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
   # throughout a build
-  EL8_REPO_NAME: ""
-  EL9_REPO_NAME: ""
+  REPO_NAME: ""
   SET_VERSION: ""
   HBASE_VERSION: ""
   PKG_RELEASE: ""

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -10,7 +10,8 @@ env:
   # The build environment requires environment variables to be explicitly defined before they may
   # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
   # throughout a build
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: ""
+  EL8_REPO_NAME: ""
+  EL9_REPO_NAME: ""
   SET_VERSION: ""
   HBASE_VERSION: ""
   PKG_RELEASE: ""

--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -65,13 +65,11 @@ RELEASE="hs"
 
 if [[ "$GIT_BRANCH" = "$MAIN_BRANCH" ]]; then
     SET_VERSION="${MINOR_VERSION}-hubspot-SNAPSHOT"
-    EL8_REPO_NAME="8_hs-hbase"
-    EL9_REPO_NAME="9_hs-hbase"
+    REPO_NAME="AnyLinuxVersion_hs-hbase"
 elif [[ "$GIT_BRANCH" != "hubspot" ]]; then
     SET_VERSION="${MINOR_VERSION}-${GIT_BRANCH}-SNAPSHOT"
     RELEASE="${RELEASE}~${GIT_BRANCH//[^[:alnum:]]/_}"
-    EL8_REPO_NAME="8_hs-hbase-develop"
-    EL9_REPO_NAME="9_hs-hbase-develop"
+    REPO_NAME="AnyLinuxVersion_hs-hbase-develop"
 else
     echo "Invalid git branch $GIT_BRANCH"
     exit 1
@@ -85,8 +83,7 @@ write-build-env-var SET_VERSION "$SET_VERSION"
 write-build-env-var HBASE_VERSION "$HBASE_VERSION"
 write-build-env-var PKG_RELEASE "$RELEASE"
 write-build-env-var FULL_BUILD_VERSION "$FULL_BUILD_VERSION"
-write-build-env-var EL8_REPO_NAME "$EL8_REPO_NAME"
-write-build-env-var EL9_REPO_NAME "$EL9_REPO_NAME"
+write-build-env-var REPO_NAME "$REPO_NAME"
 # Adding this value as versioninfo.version ensures we have the same value as would normally
 # show up in a non-hubspot hbase build. Otherwise due to set-maven-versions we'd end up
 # with 2.6-hubspot-SNAPSHOT which is not very useful as a point of reference.

--- a/build-scripts/prepare_environment.sh
+++ b/build-scripts/prepare_environment.sh
@@ -65,11 +65,13 @@ RELEASE="hs"
 
 if [[ "$GIT_BRANCH" = "$MAIN_BRANCH" ]]; then
     SET_VERSION="${MINOR_VERSION}-hubspot-SNAPSHOT"
-    YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8="8_hs-hbase"
+    EL8_REPO_NAME="8_hs-hbase"
+    EL9_REPO_NAME="9_hs-hbase"
 elif [[ "$GIT_BRANCH" != "hubspot" ]]; then
     SET_VERSION="${MINOR_VERSION}-${GIT_BRANCH}-SNAPSHOT"
     RELEASE="${RELEASE}~${GIT_BRANCH//[^[:alnum:]]/_}"
-    YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8="8_hs-hbase-develop"
+    EL8_REPO_NAME="8_hs-hbase-develop"
+    EL9_REPO_NAME="9_hs-hbase-develop"
 else
     echo "Invalid git branch $GIT_BRANCH"
     exit 1
@@ -83,7 +85,8 @@ write-build-env-var SET_VERSION "$SET_VERSION"
 write-build-env-var HBASE_VERSION "$HBASE_VERSION"
 write-build-env-var PKG_RELEASE "$RELEASE"
 write-build-env-var FULL_BUILD_VERSION "$FULL_BUILD_VERSION"
-write-build-env-var YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8 "$YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8"
+write-build-env-var EL8_REPO_NAME "$EL8_REPO_NAME"
+write-build-env-var EL9_REPO_NAME "$EL9_REPO_NAME"
 # Adding this value as versioninfo.version ensures we have the same value as would normally
 # show up in a non-hubspot hbase build. Otherwise due to set-maven-versions we'd end up
 # with 2.6-hubspot-SNAPSHOT which is not very useful as a point of reference.

--- a/hbase-rpm/.blazar.yaml
+++ b/hbase-rpm/.blazar.yaml
@@ -1,20 +1,23 @@
 buildpack:
-  name: Blazar-Buildpack-RPM
+  name: Buildpack-RPMs
 
 env:
   RPM_BUILD_COMMAND: ./build.sh
-  DISABLE_CENTOS_6_RPMS: "true"
-  ENABLE_CENTOS_8_RPMS: "true"
    # Below variables are generated in prepare_environment.sh.
   # The build environment requires environment variables to be explicitly defined before they may
   # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
   # throughout a build
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: ""
+  EL8_REPO_NAME: ""
+  EL9_REPO_NAME: ""
   SET_VERSION: ""
   HBASE_VERSION: ""
   PKG_RELEASE: ""
   FULL_BUILD_VERSION: ""
   MAVEN_BUILD_ARGS: ""
+
+enableBuildTargets:
+  - centos8_amd64
+  - almalinux9_amd64
 
 depends:
   - hbase

--- a/hbase-rpm/.blazar.yaml
+++ b/hbase-rpm/.blazar.yaml
@@ -7,8 +7,7 @@ env:
   # The build environment requires environment variables to be explicitly defined before they may
   # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
   # throughout a build
-  EL8_REPO_NAME: ""
-  EL9_REPO_NAME: ""
+  REPO_NAME: ""
   SET_VERSION: ""
   HBASE_VERSION: ""
   PKG_RELEASE: ""
@@ -17,7 +16,6 @@ env:
 
 enableBuildTargets:
   - centos8_amd64
-  - almalinux9_amd64
 
 depends:
   - hbase

--- a/hubspot-client-bundles/.blazar.yaml
+++ b/hubspot-client-bundles/.blazar.yaml
@@ -6,7 +6,7 @@ env:
   # The build environment requires environment variables to be explicitly defined before they may
   # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
   # throughout a build
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: ""
+  REPO_NAME: ""
   SET_VERSION: ""
   HBASE_VERSION: ""
   PKG_RELEASE: ""

--- a/hubspot-client-bundles/hbase-backup-restore-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-backup-restore-bundle/.blazar.yaml
@@ -6,7 +6,7 @@ env:
   # The build environment requires environment variables to be explicitly defined before they may
   # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
   # throughout a build
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: ""
+  REPO_NAME: ""
   SET_VERSION: ""
   HBASE_VERSION: ""
   PKG_RELEASE: ""

--- a/hubspot-client-bundles/hbase-client-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-client-bundle/.blazar.yaml
@@ -6,7 +6,7 @@ env:
   # The build environment requires environment variables to be explicitly defined before they may
   # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
   # throughout a build
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: ""
+  REPO_NAME: ""
   SET_VERSION: ""
   HBASE_VERSION: ""
   PKG_RELEASE: ""

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/.blazar.yaml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/.blazar.yaml
@@ -6,7 +6,7 @@ env:
   # The build environment requires environment variables to be explicitly defined before they may
   # be modified by the `write-build-env-var` utilty script to persist changes to an environment variable
   # throughout a build
-  YUM_REPO_UPLOAD_OVERRIDE_CENTOS_8: ""
+  REPO_NAME: ""
   SET_VERSION: ""
   HBASE_VERSION: ""
   PKG_RELEASE: ""


### PR DESCRIPTION
We now have the AnyLinuxVersion repos for RPMs that don't need to be different per Linux version. Let's put future builds of HBase in there.