### PR TITLE
Reuse some healthcheck code

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/HealthCheckServlet.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/HealthCheckServlet.java
@@ -23,11 +23,24 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.RpcConnectionRegistry;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.yetus.audience.InterfaceAudience;
 
 @InterfaceAudience.Private
 public abstract class HealthCheckServlet<T extends HRegionServer> extends HttpServlet {
+
+  private static final String CLIENT_RPC_TIMEOUT = "healthcheck.hbase.client.rpc.timeout";
+  private static final int CLIENT_RPC_TIMEOUT_DEFAULT = 5000;
+  private static final String CLIENT_RETRIES = "healthcheck.hbase.client.retries";
+  private static final int CLIENT_RETRIES_DEFAULT = 2;
+  private static final String CLIENT_OPERATION_TIMEOUT =
+    "healthcheck.hbase.client.operation.timeout";
+  private static final int CLIENT_OPERATION_TIMEOUT_DEFAULT = 15000;
 
   private final String serverLookupKey;
 
@@ -41,7 +54,7 @@ public abstract class HealthCheckServlet<T extends HRegionServer> extends HttpSe
     throws ServletException, IOException {
     T server = (T) getServletContext().getAttribute(serverLookupKey);
     try {
-      checkGeneric(server);
+      check(server, req);
       Optional<String> message = check(server, req);
       resp.setStatus(200);
       resp.getWriter().write(message.orElse("ok"));
@@ -53,7 +66,7 @@ public abstract class HealthCheckServlet<T extends HRegionServer> extends HttpSe
     }
   }
 
-  private void checkGeneric(T server) throws IOException {
+  private Optional<String> check(T server, HttpServletRequest req) throws IOException {
     if (server == null) {
       throw new IOException("Unable to get access to " + serverLookupKey);
     }
@@ -63,7 +76,28 @@ public abstract class HealthCheckServlet<T extends HRegionServer> extends HttpSe
     if (!server.getRpcServer().isStarted()) {
       throw new IOException("The " + serverLookupKey + "'s RpcServer is not started");
     }
+
+    Configuration conf = new Configuration(server.getConfiguration());
+    conf.set(HConstants.CLIENT_CONNECTION_REGISTRY_IMPL_CONF_KEY,
+      RpcConnectionRegistry.class.getName());
+    conf.set(RpcConnectionRegistry.BOOTSTRAP_NODES, server.getServerName().getAddress().toString());
+    conf.setInt(HConstants.HBASE_RPC_TIMEOUT_KEY,
+      conf.getInt(CLIENT_RPC_TIMEOUT, CLIENT_RPC_TIMEOUT_DEFAULT));
+    conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER,
+      conf.getInt(CLIENT_RETRIES, CLIENT_RETRIES_DEFAULT));
+    conf.setInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT,
+      conf.getInt(CLIENT_OPERATION_TIMEOUT, CLIENT_OPERATION_TIMEOUT_DEFAULT));
+
+    try (Connection conn = ConnectionFactory.createConnection(conf)) {
+      // this will fail if the server is not accepting requests
+      if (conn.getClusterId() == null) {
+        throw new IOException("Could not retrieve clusterId from self via rpc");
+      }
+
+      return check(server, req, conn);
+    }
   }
 
-  protected abstract Optional<String> check(T server, HttpServletRequest req) throws IOException;
+  protected abstract Optional<String> check(T server, HttpServletRequest req, Connection conn)
+    throws IOException;
 }


### PR DESCRIPTION
I meant to include this in #90 but apparently hadn't committed it. It basically DRY's up the healthcheck code a bit so that we can use the bootstrap nodes trick to check the RPC of regionservers too.

I tested this on a regionserver and hmaster and it seems to work. I didn't fully test the failure modes though.