### PR TITLE
HubSpot Backport: HBASE-28586 Backport HBASE-24791 Improve HFileOutputFormat2 to avoid always call getTableRelativePath method

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -262,6 +262,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
       private final Map<byte[], WriterLength> writers = new TreeMap<>(Bytes.BYTES_COMPARATOR);
       private final Map<byte[], byte[]> previousRows = new TreeMap<>(Bytes.BYTES_COMPARATOR);
       private final long now = EnvironmentEdgeManager.currentTime();
+      private byte[] tableNameBytes = writeMultipleTables ? null : Bytes.toBytes(writeTableNames);
 
       @Override
       public void write(ImmutableBytesWritable row, V cell) throws IOException {
@@ -275,7 +276,6 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
         byte[] rowKey = CellUtil.cloneRow(kv);
         int length = (PrivateCellUtil.estimatedSerializedSizeOf(kv)) - Bytes.SIZEOF_INT;
         byte[] family = CellUtil.cloneFamily(kv);
-        byte[] tableNameBytes = null;
         if (writeMultipleTables) {
           tableNameBytes = MultiTableHFileOutputFormat.getTableName(row.get());
           tableNameBytes = writeToTableWithNamespace
@@ -286,10 +286,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
             throw new IllegalArgumentException(
               "TableName " + Bytes.toString(tableNameBytes) + " not expected");
           }
-        } else {
-          tableNameBytes = Bytes.toBytes(writeTableNames);
         }
-        Path tableRelPath = getTableRelativePath(tableNameBytes);
         byte[] tableAndFamily = getTableNameSuffixedWithFamily(tableNameBytes, family);
 
         WriterLength wl = this.writers.get(tableAndFamily);
@@ -298,6 +295,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
         if (wl == null) {
           Path writerPath = null;
           if (writeMultipleTables) {
+            Path tableRelPath = getTableRelativePath(tableNameBytes);
             writerPath = new Path(outputDir, new Path(tableRelPath, Bytes.toString(family)));
           } else {
             writerPath = new Path(outputDir, Bytes.toString(family));
@@ -316,6 +314,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
 
         // create a new WAL writer, if necessary
         if (wl == null || wl.writer == null) {
+          InetSocketAddress[] favoredNodes = null;
           if (conf.getBoolean(LOCALITY_SENSITIVE_CONF_KEY, DEFAULT_LOCALITY_SENSITIVE)) {
             HRegionLocation loc = null;
             String tableName = Bytes.toString(tableNameBytes);
@@ -331,26 +330,22 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
                 loc = null;
               }
             }
-
             if (null == loc) {
               LOG.trace("Failed get of location, use default writer {}", Bytes.toString(rowKey));
-              wl = getNewWriter(tableNameBytes, family, conf, null);
             } else {
               LOG.debug("First rowkey: [{}]", Bytes.toString(rowKey));
               InetSocketAddress initialIsa =
                 new InetSocketAddress(loc.getHostname(), loc.getPort());
               if (initialIsa.isUnresolved()) {
                 LOG.trace("Failed resolve address {}, use default writer", loc.getHostnamePort());
-                wl = getNewWriter(tableNameBytes, family, conf, null);
               } else {
                 LOG.debug("Use favored nodes writer: {}", initialIsa.getHostString());
-                wl = getNewWriter(tableNameBytes, family, conf,
-                  new InetSocketAddress[] { initialIsa });
+                favoredNodes = new InetSocketAddress[] { initialIsa };
               }
             }
-          } else {
-            wl = getNewWriter(tableNameBytes, family, conf, null);
           }
+          wl = getNewWriter(tableNameBytes, family, conf, favoredNodes);
+
         }
 
         // we now have the proper WAL writer. full steam ahead
@@ -365,9 +360,9 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
       private Path getTableRelativePath(byte[] tableNameBytes) {
         String tableName = Bytes.toString(tableNameBytes);
         String[] tableNameParts = tableName.split(":");
-        Path tableRelPath = new Path(tableName.split(":")[0]);
+        Path tableRelPath = new Path(tableNameParts[0]);
         if (tableNameParts.length > 1) {
-          tableRelPath = new Path(tableRelPath, tableName.split(":")[1]);
+          tableRelPath = new Path(tableRelPath, tableNameParts[1]);
         }
         return tableRelPath;
       }


### PR DESCRIPTION
This PR backports https://issues.apache.org/jira/browse/HBASE-28586 / https://issues.apache.org/jira/browse/HBASE-24791 to our fork. @mperez and I were wondering why a bulkload of a smaller size (hundreds of GB) was taking so long today and upon taking a flamegraph, HFileOutputFormat2#getTableRelativePath was revealed to be occupying 3x more CPU time than StoreFileWriter#append (which is the exact situation described in https://issues.apache.org/jira/browse/HBASE-24791)