### PR TITLE
HubSpot Backport: HBASE-28666 Dropping unclosed WALTailingReaders leads to leaked sockets

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStream.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStream.java
@@ -220,6 +220,7 @@ class WALEntryStream implements Closeable {
             // we will read from the beginning so we should always clear the compression context
             reader.resetTo(-1, true);
           }
+          return HasNext.YES;
         } catch (FileNotFoundException e) {
           // For now, this could happen only when reading meta wal for meta replicas.
           // In this case, raising UncheckedIOException will let the endpoint deal with resetting


### PR DESCRIPTION
Backporting to stop 2.6 TCP OOMs

@charlesconnell @ksravista @hgromer 