### PR TITLE
[DRAFT] Fix invalid file meta hiding last compacted timestamp

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -2162,6 +2162,9 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
           if (val == null || !Bytes.toBoolean(val)) {
             continue;
           }
+          if (reader.getFileContext().getFileCreateTime() == 0L) {
+            continue;
+          }
         }
         result = Math.min(result, reader.getFileContext().getFileCreateTime());
       }


### PR DESCRIPTION
**Goal** Fix last compaction time for table with certain problematic bulkloads

We've noticed that some bulk loads will load a store file into the region with a missing creation timestamp. These timestamps end up causing region metrics to incorrectly determine the regions last compaction timestamp.

This PR avoids considering the timestamp of those files. This is a small problem in QA, but is also showing up in prod and affecting our safeguards around compactions. I'm not sure yet whether this is the only reason we're seeing missing timestamps.