### PR TITLE
Isolate generator cost mismatch

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/HubSpotCellCostFunction.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/HubSpotCellCostFunction.java
@@ -336,7 +336,7 @@ public class HubSpotCellCostFunction extends CostFunction {
   }
 
   static boolean isStopExclusive(byte[] endKey) {
-    return endKey != null && endKey.length > 2 && areSubsequentBytesAllZero(endKey, 2);
+    return endKey != null && endKey.length == 2 || (endKey.length > 2 && areSubsequentBytesAllZero(endKey, 2));
   }
 
   static short calcNumCells(RegionInfo[] regionInfos, short totalCellCount) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestHubSpotCellCostFunction.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestHubSpotCellCostFunction.java
@@ -105,21 +105,40 @@ public class TestHubSpotCellCostFunction {
   @Test
   public void testCostBalanced() {
     // 4 cells, 4 servers, perfectly balanced
-    int cost = HubSpotCellCostFunction.calculateCurrentCellCost((short) 4, 4,
-      new RegionInfo[] { buildRegionInfo(null, (short) 1), buildRegionInfo((short) 1, (short) 2),
-        buildRegionInfo((short) 2, (short) 3), buildRegionInfo((short) 3, null) },
-      new int[][] { { 0 }, { 1 }, { 2 }, { 3 } }, ALL_REGIONS_SIZE_1_MB);
+    int cost = HubSpotCellCostFunction.calculateCurrentCellCost
+      ((short) 4,
+        4,
+      1,
+        new RegionInfo[] {
+        buildRegionInfo(null, (short) 1),
+        buildRegionInfo((short) 1, (short) 2),
+        buildRegionInfo((short) 2, (short) 3),
+        buildRegionInfo((short) 3, null)
+      },
+        new int[][] { { 0 }, { 1 }, { 2 }, { 3 } },
+        new boolean[][] {{false, false, false, false}, {false, false, false, false}, {false, false, false, false}, {false, false, false, false}},
+        ALL_REGIONS_SIZE_1_MB
+      );
 
     assertEquals(0, cost);
   }
 
   @Test
   public void testCostImbalanced() {
-    // 4 cells, 4 servers, perfectly balanced
-    int cost = HubSpotCellCostFunction.calculateCurrentCellCost((short) 4, 4,
-      new RegionInfo[] { buildRegionInfo(null, (short) 1), buildRegionInfo((short) 1, (short) 2),
-        buildRegionInfo((short) 2, (short) 3), buildRegionInfo((short) 3, null) },
-      new int[][] { { 0 }, { 0 }, { 0 }, { 0 } }, ALL_REGIONS_SIZE_1_MB);
+    // 4 cells, 4 servers, imbalanced
+    int cost = HubSpotCellCostFunction.calculateCurrentCellCost(
+      (short) 4,
+      4,
+      1,
+      new RegionInfo[] {
+        buildRegionInfo(null, (short) 1),
+        buildRegionInfo((short) 1, (short) 2),
+        buildRegionInfo((short) 2, (short) 3),
+        buildRegionInfo((short) 3, null)
+      },
+      new int[][] { { 0 }, { 0 }, { 0 }, { 0 } },
+      new boolean[][] {{false, false, false, false}, {false, false, false, false}, {false, false, false, false}, {false, false, false, false}},
+      ALL_REGIONS_SIZE_1_MB);
     assertTrue(cost > 0);
   }
 


### PR DESCRIPTION
This PR rewords how the cost calculator evaluates. The initial implementation put all the work in the `cost` function, but after looking at other cost functions for inspiration it's clear that the template is to calculate the cost up front during the `prepare` call, and then make iterative adjustments as the stochastic balancer runs via the `regionMoved` method. The stochastic balancer assumes that the `cost` function is cheap to compute, and invokes it repeatedly. The stochastic balancer uses a greedy (though randomized) approach by applying one change at a time, and if it takes the cost in a negative direction, reversing it. This means we'll apply a lot of region moves (and then their inverse), but the logic for cost can be partially applied rather than having to recalculate the entire cost across all regions and servers.