### PR TITLE
Target a specific capped cell count

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestHubSpotCellCostFunction.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestHubSpotCellCostFunction.java
@@ -106,7 +106,7 @@ public class TestHubSpotCellCostFunction {
   @Test
   public void testCostBalanced() {
     // 4 cells, 4 servers, perfectly balanced
-    int cost = HubSpotCellCostFunction.calculateCurrentCellCost
+    int cost = HubSpotCellCostFunction.calculateCurrentCountOfCellsOutsideDesiredBand
       ((short) 4,
         4,
       1,
@@ -127,7 +127,7 @@ public class TestHubSpotCellCostFunction {
   @Test
   public void testCostImbalanced() {
     // 4 cells, 4 servers, imbalanced
-    int cost = HubSpotCellCostFunction.calculateCurrentCellCost(
+    int cost = HubSpotCellCostFunction.calculateCurrentCountOfCellsOutsideDesiredBand(
       (short) 4,
       4,
       1,


### PR DESCRIPTION
This PR modifies the cell-aware balancer to prioritize dispersion of cells _up to a specific max_. It's hard-coded to 10% of the overall cell count, which means the balancer will disperse cells (prioritizing performance) up to a 10% colocation max, but will respect isolation beyond that point and pack cells together as needed. This makes the balancing behavior (from an isolation perspective) independent of the count of regions or region servers that a cluster is configured with.