### PR TITLE
Small clusters may not have enough regions/cell to support lower isolation

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/hubspot/HubSpotCellUtilities.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/hubspot/HubSpotCellUtilities.java
@@ -1,5 +1,6 @@
 package org.apache.hadoop.hbase.hubspot;
 
+import com.google.common.primitives.Ints;
 import org.agrona.collections.Int2IntCounterMap;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
@@ -31,7 +32,7 @@ import java.util.stream.IntStream;
 public final class HubSpotCellUtilities {
   // TODO: this should be dynamically configured, not hard-coded, but this dramatically simplifies the initial version
   public static final short MAX_CELL_COUNT = 360;
-  public static final int MAX_CELLS_PER_RS = 36;
+  private static final int TARGET_MAX_CELLS_PER_RS = 36;
 
   public static final Gson OBJECT_MAPPER = new GsonBuilder()
     .excludeFieldsWithoutExposeAnnotation()
@@ -84,6 +85,13 @@ public final class HubSpotCellUtilities {
   public static final ImmutableSet<String> CELL_AWARE_TABLES = ImmutableSet.of("objects-3");
 
   private HubSpotCellUtilities() {}
+
+  public static int getMaxCellsPerRs(int servers) {
+    return Math.max(
+      TARGET_MAX_CELLS_PER_RS,
+      Ints.checkedCast( (long)Math.floor((double) MAX_CELL_COUNT / servers))
+    );
+  }
 
   public static String toCellSetString(Set<Short> cells) {
     return cells.stream().sorted().map(x -> Short.toString(x)).collect(Collectors.joining(", ", "{", "}"));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/HubSpotCellBasedCandidateGenerator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/HubSpotCellBasedCandidateGenerator.java
@@ -106,7 +106,7 @@ import org.apache.hbase.thirdparty.com.google.common.primitives.Ints;
     }
 
     int targetCellsPerServer = targetRegionsPerServer - numTimesCellRegionsFillAllServers;
-    targetCellsPerServer = Math.min(targetCellsPerServer, HubSpotCellUtilities.MAX_CELLS_PER_RS);
+    targetCellsPerServer = Math.min(targetCellsPerServer, HubSpotCellUtilities.getMaxCellsPerRs(cluster.numServers));
     Set<Integer> serversBelowTarget = new HashSet<>();
     Set<Integer> serversAboveTarget = new HashSet<>();
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/HubSpotCellCostFunction.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/HubSpotCellCostFunction.java
@@ -132,7 +132,7 @@ public class HubSpotCellCostFunction extends CostFunction {
     }
 
     bestCaseMaxCellsPerServer -= numTimesCellRegionsFillAllServers;
-    bestCaseMaxCellsPerServer = Math.min(bestCaseMaxCellsPerServer, HubSpotCellUtilities.MAX_CELLS_PER_RS);
+    bestCaseMaxCellsPerServer = Math.min(bestCaseMaxCellsPerServer, HubSpotCellUtilities.getMaxCellsPerRs(cluster.numServers));
     this.maxAcceptableCellsPerServer = bestCaseMaxCellsPerServer;
     this.balancedRegionsPerServer = Ints.checkedCast(
       (long) Math.floor((double) cluster.numRegions / cluster.numServers));


### PR DESCRIPTION
TLDR: need to run at least 10 servers, to allow enforcing 10% isolation. This update tweaks how we compute the max targeted cells/server to be aware of the cluster and handle small clusters.