### PR TITLE
HBASE-28513 The StochasticLoadBalancer should support discrete evaluations

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalanceAction.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalanceAction.java
@@ -28,6 +28,7 @@ abstract class BalanceAction {
     ASSIGN_REGION,
     MOVE_REGION,
     SWAP_REGIONS,
+    MOVE_BATCH,
     NULL,
   }
 
@@ -49,6 +50,10 @@ abstract class BalanceAction {
 
   Type getType() {
     return type;
+  }
+
+  long getStepCount() {
+    return 1;
   }
 
   @Override

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
@@ -26,6 +26,8 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.agrona.collections.Hashing;
 import org.agrona.collections.Int2IntCounterMap;
 import org.apache.hadoop.hbase.HDFSBlocksDistribution;
@@ -33,11 +35,16 @@ import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.master.RackManager;
+import org.apache.hadoop.hbase.master.RegionPlan;
 import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.base.Supplier;
+import org.apache.hbase.thirdparty.com.google.common.base.Suppliers;
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableList;
 
 /**
  * An efficient array based implementation similar to ClusterState for keeping the status of the
@@ -122,6 +129,14 @@ class BalancerClusterState {
   private int[] regionServerIndexWithBestRegionCachedRatio;
   // Maps regionName -> oldServerName -> cache ratio of the region on the old server
   Map<String, Pair<ServerName, Float>> regionCacheRatioOnOldServerMap;
+
+  private Supplier<List<Integer>> shuffledServerIndicesSupplier =
+    Suppliers.memoizeWithExpiration(() -> {
+      Collection<Integer> serverIndices = serversToIndex.values();
+      List<Integer> shuffledServerIndices = new ArrayList<>(serverIndices);
+      Collections.shuffle(shuffledServerIndices);
+      return shuffledServerIndices;
+    }, 5, TimeUnit.SECONDS);
 
   static class DefaultRackManager extends RackManager {
     @Override
@@ -711,6 +726,44 @@ class BalancerClusterState {
     RACK
   }
 
+  public List<RegionPlan> convertActionToPlans(BalanceAction action) {
+    switch (action.getType()) {
+      case NULL:
+        break;
+      case ASSIGN_REGION:
+        // FindBugs: Having the assert quietens FB BC_UNCONFIRMED_CAST warnings
+        assert action instanceof AssignRegionAction : action.getClass();
+        AssignRegionAction ar = (AssignRegionAction) action;
+        return ImmutableList
+          .of(new RegionPlan(regions[ar.getRegion()], null, servers[ar.getServer()]));
+      case MOVE_REGION:
+        assert action instanceof MoveRegionAction : action.getClass();
+        MoveRegionAction mra = (MoveRegionAction) action;
+        return ImmutableList.of(new RegionPlan(regions[mra.getRegion()],
+          servers[mra.getFromServer()], servers[mra.getToServer()]));
+      case SWAP_REGIONS:
+        assert action instanceof SwapRegionsAction : action.getClass();
+        SwapRegionsAction a = (SwapRegionsAction) action;
+        return ImmutableList.of(
+          new RegionPlan(regions[a.getFromRegion()], servers[a.getFromServer()],
+            servers[a.getToServer()]),
+          new RegionPlan(regions[a.getToRegion()], servers[a.getToServer()],
+            servers[a.getFromServer()]));
+      case MOVE_BATCH:
+        assert action instanceof MoveBatchAction : action.getClass();
+        MoveBatchAction mba = (MoveBatchAction) action;
+        List<RegionPlan> mbRegionPlans = new ArrayList<>();
+        for (MoveRegionAction moveRegionAction : mba.getMoveActions()) {
+          mbRegionPlans.add(new RegionPlan(regions[moveRegionAction.getRegion()],
+            servers[moveRegionAction.getFromServer()], servers[moveRegionAction.getToServer()]));
+        }
+        return mbRegionPlans;
+      default:
+        throw new RuntimeException("Unknown action:" + action.getType());
+    }
+    return Collections.emptyList();
+  }
+
   public void doAction(BalanceAction action) {
     switch (action.getType()) {
       case NULL:
@@ -742,8 +795,25 @@ class BalancerClusterState {
         regionMoved(a.getFromRegion(), a.getFromServer(), a.getToServer());
         regionMoved(a.getToRegion(), a.getToServer(), a.getFromServer());
         break;
+      case MOVE_BATCH:
+        assert action instanceof MoveBatchAction : action.getClass();
+        MoveBatchAction mba = (MoveBatchAction) action;
+        for (int serverIndex : mba.getServerToRegionsToRemove().keySet()) {
+          Set<Integer> regionsToRemove = mba.getServerToRegionsToRemove().get(serverIndex);
+          regionsPerServer[serverIndex] =
+            removeRegions(regionsPerServer[serverIndex], regionsToRemove);
+        }
+        for (int serverIndex : mba.getServerToRegionsToAdd().keySet()) {
+          Set<Integer> regionsToAdd = mba.getServerToRegionsToAdd().get(serverIndex);
+          regionsPerServer[serverIndex] = addRegions(regionsPerServer[serverIndex], regionsToAdd);
+        }
+        for (MoveRegionAction moveRegionAction : mba.getMoveActions()) {
+          regionMoved(moveRegionAction.getRegion(), moveRegionAction.getFromServer(),
+            moveRegionAction.getToServer());
+        }
+        break;
       default:
-        throw new RuntimeException("Uknown action:" + action.getType());
+        throw new RuntimeException("Unknown action:" + action.getType());
     }
   }
 
@@ -903,6 +973,52 @@ class BalancerClusterState {
     System.arraycopy(regions, 0, newRegions, 0, regions.length);
     newRegions[newRegions.length - 1] = regionIndex;
     return newRegions;
+  }
+
+  int[] removeRegions(int[] regions, Set<Integer> regionIndicesToRemove) {
+    // Calculate the size of the new regions array
+    int newSize = regions.length - regionIndicesToRemove.size();
+    if (newSize < 0) {
+      throw new IllegalStateException(
+        "Region indices mismatch: more regions to remove than in the regions array");
+    }
+
+    int[] newRegions = new int[newSize];
+    int newIndex = 0;
+
+    // Copy only the regions not in the removal set
+    for (int region : regions) {
+      if (!regionIndicesToRemove.contains(region)) {
+        newRegions[newIndex++] = region;
+      }
+    }
+
+    // If the newIndex is smaller than newSize, some regions were missing from the input array
+    if (newIndex != newSize) {
+      throw new IllegalStateException("Region indices mismatch: some regions in the removal "
+        + "set were not found in the regions array");
+    }
+
+    return newRegions;
+  }
+
+  int[] addRegions(int[] regions, Set<Integer> regionIndicesToAdd) {
+    int[] newRegions = new int[regions.length + regionIndicesToAdd.size()];
+
+    // Copy the existing regions to the new array
+    System.arraycopy(regions, 0, newRegions, 0, regions.length);
+
+    // Add the new regions at the end of the array
+    int newIndex = regions.length;
+    for (int regionIndex : regionIndicesToAdd) {
+      newRegions[newIndex++] = regionIndex;
+    }
+
+    return newRegions;
+  }
+
+  List<Integer> getShuffledServerIndices() {
+    return shuffledServerIndicesSupplier.get();
   }
 
   int[] addRegionSorted(int[] regions, int regionIndex) {

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerConditionals.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerConditionals.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.master.RegionPlan;
+import org.apache.hadoop.hbase.util.ReflectionUtils;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
+
+/**
+ * Balancer conditionals supplement cost functions in the {@link StochasticLoadBalancer}. Cost
+ * functions are insufficient and difficult to work with when making discrete decisions; this is
+ * because they operate on a continuous scale, and each cost function's multiplier affects the
+ * relative importance of every other cost function. So it is difficult to meaningfully and clearly
+ * value many aspects of your region distribution via cost functions alone. Conditionals allow you
+ * to very clearly define discrete rules that your balancer would ideally follow. To clarify, a
+ * conditional violation will not block a region assignment because we would prefer to have uptime
+ * than have perfectly intentional balance. But conditionals allow you to, for example, define that
+ * a region's primary and secondary should not live on the same rack. Another example, conditionals
+ * make it easy to define that system tables will ideally be isolated on their own RegionServer
+ * (without needing to manage distinct RegionServer groups). Use of conditionals may cause an
+ * extremely unbalanced cluster to exceed its max balancer runtime. This is necessary because
+ * conditional candidate generation is quite expensive, and cutting it off early could prevent us
+ * from finding a solution.
+ */
+@InterfaceAudience.Private
+final class BalancerConditionals implements Configurable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BalancerConditionals.class);
+
+  static final BalancerConditionals INSTANCE = new BalancerConditionals();
+  public static final String DISTRIBUTE_REPLICAS_KEY =
+    "hbase.master.balancer.stochastic.conditionals.distributeReplicas";
+  public static final boolean DISTRIBUTE_REPLICAS_DEFAULT = false;
+
+  public static final String ADDITIONAL_CONDITIONALS_KEY =
+    "hbase.master.balancer.stochastic.additionalConditionals";
+
+  private Set<Class<? extends RegionPlanConditional>> conditionalClasses = Collections.emptySet();
+  private Set<RegionPlanConditional> conditionals = Collections.emptySet();
+  private Configuration conf;
+
+  private BalancerConditionals() {
+  }
+
+  boolean shouldRunBalancer(BalancerClusterState cluster) {
+    return isConditionalBalancingEnabled() && conditionals.stream()
+      .map(RegionPlanConditional::getCandidateGenerators).flatMap(Collection::stream)
+      .map(generator -> generator.getWeight(cluster)).anyMatch(weight -> weight > 0);
+  }
+
+  Set<Class<? extends RegionPlanConditional>> getConditionalClasses() {
+    return Set.copyOf(conditionalClasses);
+  }
+
+  Collection<RegionPlanConditional> getConditionals() {
+    return conditionals;
+  }
+
+  boolean isReplicaDistributionEnabled() {
+    return conditionalClasses.contains(DistributeReplicasConditional.class);
+  }
+
+  boolean shouldSkipSloppyServerEvaluation() {
+    return isConditionalBalancingEnabled();
+  }
+
+  boolean isConditionalBalancingEnabled() {
+    return !conditionalClasses.isEmpty();
+  }
+
+  void clearConditionalWeightCaches() {
+    conditionals.stream().map(RegionPlanConditional::getCandidateGenerators)
+      .flatMap(Collection::stream)
+      .forEach(RegionPlanConditionalCandidateGenerator::clearWeightCache);
+  }
+
+  void loadClusterState(BalancerClusterState cluster) {
+    conditionals = conditionalClasses.stream().map(clazz -> createConditional(clazz, conf, cluster))
+      .filter(Objects::nonNull).collect(Collectors.toSet());
+  }
+
+  /**
+   * Indicates whether the action is good for our conditional compliance.
+   * @param cluster The cluster state
+   * @param action  The proposed action
+   * @return -1 if conditionals improve, 0 if neutral, 1 if conditionals degrade
+   */
+  int getViolationCountChange(BalancerClusterState cluster, BalanceAction action) {
+    boolean isViolatingPre = isViolating(cluster, action.undoAction());
+    boolean isViolatingPost = isViolating(cluster, action);
+    if (isViolatingPre && isViolatingPost) {
+      return 0;
+    } else if (!isViolatingPre && isViolatingPost) {
+      return 1;
+    } else {
+      return -1;
+    }
+  }
+
+  /**
+   * Check if the proposed action violates conditionals
+   * @param cluster The cluster state
+   * @param action  The proposed action
+   */
+  boolean isViolating(BalancerClusterState cluster, BalanceAction action) {
+    conditionals.forEach(conditional -> conditional.refreshClusterState(cluster));
+    if (conditionals.isEmpty()) {
+      return false;
+    }
+    List<RegionPlan> regionPlans = cluster.convertActionToPlans(action);
+    for (RegionPlan regionPlan : regionPlans) {
+      if (isViolating(regionPlan)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isViolating(RegionPlan regionPlan) {
+    for (RegionPlanConditional conditional : conditionals) {
+      if (conditional.isViolating(regionPlan)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private RegionPlanConditional createConditional(Class<? extends RegionPlanConditional> clazz,
+    Configuration conf, BalancerClusterState cluster) {
+    if (conf == null) {
+      conf = new Configuration();
+    }
+    if (cluster == null) {
+      cluster = new BalancerClusterState(Collections.emptyMap(), null, null, null, null);
+    }
+    try {
+      Constructor<? extends RegionPlanConditional> ctor =
+        clazz.getDeclaredConstructor(Configuration.class, BalancerClusterState.class);
+      return ReflectionUtils.instantiate(clazz.getName(), ctor, conf, cluster);
+    } catch (NoSuchMethodException e) {
+      LOG.warn("Cannot find constructor with Configuration and "
+        + "BalancerClusterState parameters for class '{}': {}", clazz.getName(), e.getMessage());
+    }
+    return null;
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+    ImmutableSet.Builder<Class<? extends RegionPlanConditional>> conditionalClasses =
+      ImmutableSet.builder();
+
+    boolean distributeReplicas =
+      conf.getBoolean(DISTRIBUTE_REPLICAS_KEY, DISTRIBUTE_REPLICAS_DEFAULT);
+    if (distributeReplicas) {
+      conditionalClasses.add(DistributeReplicasConditional.class);
+    }
+
+    Class<?>[] classes = conf.getClasses(ADDITIONAL_CONDITIONALS_KEY);
+    for (Class<?> clazz : classes) {
+      if (!RegionPlanConditional.class.isAssignableFrom(clazz)) {
+        LOG.warn("Class {} is not a RegionPlanConditional", clazz.getName());
+        continue;
+      }
+      conditionalClasses.add(clazz.asSubclass(RegionPlanConditional.class));
+    }
+    this.conditionalClasses = conditionalClasses.build();
+    loadClusterState(null);
+  }
+
+  @Override
+  public Configuration getConf() {
+    return conf;
+  }
+}

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CandidateGenerator.java
@@ -28,6 +28,8 @@ import org.apache.yetus.audience.InterfaceAudience;
 @InterfaceAudience.Private
 abstract class CandidateGenerator {
 
+  protected static double MAX_WEIGHT = 1.0;
+
   abstract BalanceAction generate(BalancerClusterState cluster);
 
   /**

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CostFunction.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CostFunction.java
@@ -76,6 +76,13 @@ abstract class CostFunction {
         regionMoved(a.getFromRegion(), a.getFromServer(), a.getToServer());
         regionMoved(a.getToRegion(), a.getToServer(), a.getFromServer());
         break;
+      case MOVE_BATCH:
+        MoveBatchAction mba = (MoveBatchAction) action;
+        for (MoveRegionAction moveRegionAction : mba.getMoveActions()) {
+          regionMoved(moveRegionAction.getRegion(), moveRegionAction.getFromServer(),
+            moveRegionAction.getToServer());
+        }
+        break;
       default:
         throw new RuntimeException("Uknown action:" + action.getType());
     }

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/DistributeReplicasCandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/DistributeReplicasCandidateGenerator.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import static org.apache.hadoop.hbase.master.balancer.DistributeReplicasConditional.getReplicaKey;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * CandidateGenerator to distribute colocated replicas across different servers.
+ */
+@InterfaceAudience.Private
+final class DistributeReplicasCandidateGenerator extends RegionPlanConditionalCandidateGenerator {
+
+  static DistributeReplicasCandidateGenerator INSTANCE = new DistributeReplicasCandidateGenerator();
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(DistributeReplicasCandidateGenerator.class);
+  private static final int BATCH_SIZE = 100_000;
+
+  private DistributeReplicasCandidateGenerator() {
+  }
+
+  /**
+   * Generates a balancing action to distribute colocated replicas. Moves one replica of a colocated
+   * region to a different server.
+   * @param cluster    Current state of the cluster.
+   * @param isWeighing Flag indicating if the generator is being used for weighing.
+   * @return A BalanceAction to move a replica or NULL_ACTION if no action is needed.
+   */
+  @Override
+  BalanceAction generateCandidate(BalancerClusterState cluster, boolean isWeighing) {
+    return generateCandidate(cluster, isWeighing, false);
+  }
+
+  BalanceAction generateCandidate(BalancerClusterState cluster, boolean isWeighing,
+    boolean isForced) {
+    // Iterate through shuffled servers to find colocated replicas
+    boolean foundColocatedReplicas = false;
+    List<MoveRegionAction> moveRegionActions = new ArrayList<>();
+    for (int sourceIndex : cluster.getShuffledServerIndices()) {
+      int[] serverRegions = cluster.regionsPerServer[sourceIndex];
+      Set<DistributeReplicasConditional.ReplicaKey> replicaKeys =
+        new HashSet<>(serverRegions.length);
+      for (int regionIndex : serverRegions) {
+        DistributeReplicasConditional.ReplicaKey replicaKey =
+          getReplicaKey(cluster.regions[regionIndex]);
+        if (replicaKeys.contains(replicaKey)) {
+          foundColocatedReplicas = true;
+          if (isWeighing) {
+            // If weighing, fast exit with an actionable move
+            return getAction(sourceIndex, regionIndex, pickOtherRandomServer(cluster, sourceIndex),
+              -1);
+          } else {
+            // If not weighing, pick a good move
+            for (int i = 0; i < cluster.numServers; i++) {
+              // Randomize destination ordering so we aren't overloading one destination
+              int destinationIndex = pickOtherRandomServer(cluster, sourceIndex);
+              if (destinationIndex == sourceIndex) {
+                continue;
+              }
+              MoveRegionAction possibleAction =
+                new MoveRegionAction(regionIndex, sourceIndex, destinationIndex);
+              if (isForced) {
+                return possibleAction;
+              } else if (willBeAccepted(cluster, possibleAction)) {
+                cluster.doAction(possibleAction); // Update cluster state to reflect move
+                moveRegionActions.add(possibleAction);
+                break;
+              }
+            }
+          }
+        } else {
+          replicaKeys.add(replicaKey);
+        }
+        if (moveRegionActions.size() >= BATCH_SIZE) {
+          break;
+        }
+      }
+      if (moveRegionActions.size() >= BATCH_SIZE) {
+        break;
+      }
+    }
+
+    if (!moveRegionActions.isEmpty()) {
+      return batchMovesAndResetClusterState(cluster, moveRegionActions);
+    }
+    // If no colocated replicas are found, return NULL_ACTION
+    if (foundColocatedReplicas) {
+      LOG.warn("Could not find a place to put a colocated replica! We will force a move.");
+      return generateCandidate(cluster, isWeighing, true);
+    } else {
+      LOG.trace("No colocated replicas found. No balancing action required.");
+    }
+    return BalanceAction.NULL_ACTION;
+  }
+}

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/DistributeReplicasConditional.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/DistributeReplicasConditional.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionReplicaUtil;
+import org.apache.hadoop.hbase.master.RegionPlan;
+import org.apache.hadoop.hbase.util.Pair;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.cache.CacheBuilder;
+import org.apache.hbase.thirdparty.com.google.common.cache.CacheLoader;
+import org.apache.hbase.thirdparty.com.google.common.cache.LoadingCache;
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableList;
+
+/**
+ * If enabled, this class will help the balancer ensure that replicas aren't placed on the same
+ * servers or racks as their primary. Configure this via
+ * {@link BalancerConditionals#DISTRIBUTE_REPLICAS_KEY}
+ */
+@InterfaceAudience.Private
+public class DistributeReplicasConditional extends RegionPlanConditional {
+
+  /**
+   * Local mini cluster tests are only run on one host/rack by design. If enabled, this will pretend
+   * that only server isolation is necessary for sufficient replica distribution. This should only
+   * be used in tests.
+   */
+  public static final String TEST_MODE_ENABLED_KEY =
+    "hbase.replica.distribution.conditional.testModeEnabled";
+
+  /**
+   * ReplicaKey creation is expensive if you have lots of regions. If your HMaster has adequate
+   * memory, and you would like balancing to be faster, then you can turn on this flag to cache
+   * ReplicaKey objects.
+   */
+  public static final String CACHE_REPLICA_KEYS_KEY =
+    "hbase.replica.distribution.conditional.cacheReplicaKeys";
+  public static final boolean CACHE_REPLICA_KEYS_DEFAULT = false;
+
+  private static final Logger LOG = LoggerFactory.getLogger(DistributeReplicasConditional.class);
+
+  private static LoadingCache<RegionInfo, ReplicaKey> REPLICA_KEY_CACHE = null;
+
+  private final boolean isTestModeEnabled;
+  private final float slop;
+
+  public DistributeReplicasConditional(Configuration conf, BalancerClusterState cluster) {
+    super(conf, cluster);
+    this.isTestModeEnabled = conf.getBoolean(TEST_MODE_ENABLED_KEY, false);
+    this.slop =
+      conf.getFloat(BaseLoadBalancer.REGIONS_SLOP_KEY, BaseLoadBalancer.REGIONS_SLOP_DEFAULT);
+    if (conf.getBoolean(CACHE_REPLICA_KEYS_KEY, CACHE_REPLICA_KEYS_DEFAULT)) {
+      REPLICA_KEY_CACHE = CacheBuilder.newBuilder().maximumSize(cluster.numRegions)
+        .expireAfterAccess(Duration.ofMinutes(30)).build(new CacheLoader<RegionInfo, ReplicaKey>() {
+          @Override
+          public ReplicaKey load(RegionInfo regionInfo) {
+            return new ReplicaKey(regionInfo);
+          }
+        });
+    }
+  }
+
+  static ReplicaKey getReplicaKey(RegionInfo regionInfo) {
+    if (REPLICA_KEY_CACHE == null) {
+      return new ReplicaKey(regionInfo);
+    } else {
+      return REPLICA_KEY_CACHE.getUnchecked(regionInfo);
+    }
+  }
+
+  @Override
+  public ValidationLevel getValidationLevel() {
+    if (isTestModeEnabled) {
+      return ValidationLevel.SERVER;
+    }
+    return ValidationLevel.RACK;
+  }
+
+  @Override
+  List<RegionPlanConditionalCandidateGenerator> getCandidateGenerators() {
+    return ImmutableList.of(DistributeReplicasCandidateGenerator.INSTANCE,
+      new SlopFixingCandidateGenerator(slop));
+  }
+
+  @Override
+  boolean isViolatingServer(RegionPlan regionPlan, Set<RegionInfo> serverRegions) {
+    return checkViolation(regionPlan.getRegionInfo(), getReplicaKey(regionPlan.getRegionInfo()),
+      serverRegions);
+  }
+
+  @Override
+  boolean isViolatingHost(RegionPlan regionPlan, Set<RegionInfo> hostRegions) {
+    return checkViolation(regionPlan.getRegionInfo(), getReplicaKey(regionPlan.getRegionInfo()),
+      hostRegions);
+  }
+
+  @Override
+  boolean isViolatingRack(RegionPlan regionPlan, Set<RegionInfo> rackRegions) {
+    return checkViolation(regionPlan.getRegionInfo(), getReplicaKey(regionPlan.getRegionInfo()),
+      rackRegions);
+  }
+
+  private boolean checkViolation(RegionInfo movingRegion, ReplicaKey movingReplicaKey,
+    Set<RegionInfo> destinationRegions) {
+    for (RegionInfo regionInfo : destinationRegions) {
+      if (regionInfo.equals(movingRegion)) {
+        continue;
+      }
+      if (getReplicaKey(regionInfo).equals(movingReplicaKey)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * This is necessary because it would be too expensive to use
+   * {@link RegionReplicaUtil#isReplicasForSameRegion(RegionInfo, RegionInfo)} for every combo of
+   * regions.
+   */
+  static class ReplicaKey {
+    private final Pair<ByteArrayWrapper, ByteArrayWrapper> startAndStopKeys;
+
+    ReplicaKey(RegionInfo regionInfo) {
+      this.startAndStopKeys = new Pair<>(new ByteArrayWrapper(regionInfo.getStartKey()),
+        new ByteArrayWrapper(regionInfo.getEndKey()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ReplicaKey)) {
+        return false;
+      }
+      ReplicaKey other = (ReplicaKey) o;
+      return this.startAndStopKeys.equals(other.startAndStopKeys);
+    }
+
+    @Override
+    public int hashCode() {
+      return startAndStopKeys.hashCode();
+    }
+  }
+
+  static class ByteArrayWrapper {
+    private final byte[] bytes;
+
+    ByteArrayWrapper(byte[] prefix) {
+      this.bytes = Arrays.copyOf(prefix, prefix.length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ByteArrayWrapper)) {
+        return false;
+      }
+      ByteArrayWrapper other = (ByteArrayWrapper) o;
+      return Arrays.equals(this.bytes, other.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(bytes);
+    }
+  }
+
+}

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/FavoredStochasticBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/FavoredStochasticBalancer.java
@@ -90,7 +90,7 @@ public class FavoredStochasticBalancer extends StochasticLoadBalancer
 
   /** Returns any candidate generator in random */
   @Override
-  protected CandidateGenerator getRandomGenerator() {
+  protected CandidateGenerator getRandomGenerator(BalancerClusterState cluster) {
     Class<? extends CandidateGenerator> clazz = shuffledGeneratorClasses.get()
       .get(ThreadLocalRandom.current().nextInt(candidateGenerators.size()));
     return candidateGenerators.get(clazz);

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/MoveBatchAction.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/MoveBatchAction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import java.util.List;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.HashMultimap;
+import org.apache.hbase.thirdparty.com.google.common.collect.Multimaps;
+
+@InterfaceAudience.Private
+public class MoveBatchAction extends BalanceAction {
+  private final List<MoveRegionAction> moveActions;
+
+  MoveBatchAction(List<MoveRegionAction> moveActions) {
+    super(Type.MOVE_BATCH);
+    this.moveActions = moveActions;
+  }
+
+  @Override
+  long getStepCount() {
+    return moveActions.size();
+  }
+
+  public HashMultimap<Integer, Integer> getServerToRegionsToRemove() {
+    return moveActions.stream().collect(Multimaps.toMultimap(MoveRegionAction::getFromServer,
+      MoveRegionAction::getRegion, HashMultimap::create));
+  }
+
+  public HashMultimap<Integer, Integer> getServerToRegionsToAdd() {
+    return moveActions.stream().collect(Multimaps.toMultimap(MoveRegionAction::getToServer,
+      MoveRegionAction::getRegion, HashMultimap::create));
+  }
+
+  List<MoveRegionAction> getMoveActions() {
+    return moveActions;
+  }
+}

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/RegionPlanConditional.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/RegionPlanConditional.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.master.RegionPlan;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public abstract class RegionPlanConditional {
+  private static final Logger LOG = LoggerFactory.getLogger(RegionPlanConditional.class);
+  private BalancerClusterState cluster;
+
+  RegionPlanConditional(Configuration conf, BalancerClusterState cluster) {
+    this.cluster = cluster;
+  }
+
+  public enum ValidationLevel {
+    SERVER, // Just check server
+    HOST, // Check host and server
+    RACK // Check rack, host, and server
+  }
+
+  public ValidationLevel getValidationLevel() {
+    return ValidationLevel.SERVER;
+  }
+
+  void refreshClusterState(BalancerClusterState cluster) {
+    this.cluster = cluster;
+  }
+
+  /**
+   * Get the candidate generator(s) for this conditional. This can be useful to provide the balancer
+   * with hints that will appease your conditional. Your conditionals will be triggered in order.
+   * @return the candidate generator for this conditional
+   */
+  abstract List<RegionPlanConditionalCandidateGenerator> getCandidateGenerators();
+
+  /**
+   * Check if the conditional is violated by the given region plan.
+   * @param regionPlan the region plan to check
+   * @return true if the conditional is violated
+   */
+  boolean isViolating(RegionPlan regionPlan) {
+    if (regionPlan == null) {
+      return false;
+    }
+    int destinationServerIdx = cluster.serversToIndex.get(regionPlan.getDestination().getAddress());
+
+    // Check Server
+    int[] destinationRegionIndices = cluster.regionsPerServer[destinationServerIdx];
+    Set<RegionInfo> serverRegions = new HashSet<>(destinationRegionIndices.length);
+    for (int regionIdx : destinationRegionIndices) {
+      serverRegions.add(cluster.regions[regionIdx]);
+    }
+    if (isViolatingServer(regionPlan, serverRegions)) {
+      return true;
+    }
+
+    if (getValidationLevel() == ValidationLevel.SERVER) {
+      return false;
+    }
+
+    // Check Host
+    int hostIdx = cluster.serverIndexToHostIndex[destinationServerIdx];
+    int[] hostRegionIndices = cluster.regionsPerHost[hostIdx];
+    Set<RegionInfo> hostRegions = new HashSet<>(hostRegionIndices.length);
+    for (int regionIdx : hostRegionIndices) {
+      hostRegions.add(cluster.regions[regionIdx]);
+    }
+    if (isViolatingHost(regionPlan, hostRegions)) {
+      return true;
+    }
+
+    if (getValidationLevel() == ValidationLevel.HOST) {
+      return false;
+    }
+
+    // Check Rack
+    int rackIdx = cluster.serverIndexToRackIndex[destinationServerIdx];
+    int[] rackRegionIndices = cluster.regionsPerRack[rackIdx];
+    Set<RegionInfo> rackRegions = new HashSet<>(rackRegionIndices.length);
+    for (int regionIdx : rackRegionIndices) {
+      rackRegions.add(cluster.regions[regionIdx]);
+    }
+    if (isViolatingRack(regionPlan, rackRegions)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  abstract boolean isViolatingServer(RegionPlan regionPlan, Set<RegionInfo> destinationRegions);
+
+  boolean isViolatingHost(RegionPlan regionPlan, Set<RegionInfo> destinationRegions) {
+    return false;
+  }
+
+  boolean isViolatingRack(RegionPlan regionPlan, Set<RegionInfo> destinationRegions) {
+    return false;
+  }
+}

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/RegionPlanConditionalCandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/RegionPlanConditionalCandidateGenerator.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import java.time.Duration;
+import java.util.List;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public abstract class RegionPlanConditionalCandidateGenerator extends CandidateGenerator {
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(RegionPlanConditionalCandidateGenerator.class);
+
+  private static final Duration WEIGHT_CACHE_TTL = Duration.ofMinutes(1);
+  private long lastWeighedAt = -1;
+  private double lastWeight = 0.0;
+
+  abstract BalanceAction generateCandidate(BalancerClusterState cluster, boolean isWeighing);
+
+  @Override
+  BalanceAction generate(BalancerClusterState cluster) {
+    BalanceAction balanceAction = generateCandidate(cluster, false);
+    if (!willBeAccepted(cluster, balanceAction)) {
+      LOG.debug("Generated action is not widely accepted by all conditionals. "
+        + "Likely we are finding our way out of a deadlock. balanceAction={}", balanceAction);
+    }
+    return balanceAction;
+  }
+
+  MoveBatchAction batchMovesAndResetClusterState(BalancerClusterState cluster,
+    List<MoveRegionAction> moves) {
+    MoveBatchAction batchAction = new MoveBatchAction(moves);
+    undoBatchAction(cluster, batchAction);
+    return batchAction;
+  }
+
+  boolean willBeAccepted(BalancerClusterState cluster, BalanceAction action) {
+    return !BalancerConditionals.INSTANCE.isViolating(cluster, action);
+  }
+
+  void undoBatchAction(BalancerClusterState cluster, MoveBatchAction batchAction) {
+    for (int i = batchAction.getMoveActions().size() - 1; i >= 0; i--) {
+      MoveRegionAction action = batchAction.getMoveActions().get(i);
+      cluster.doAction(action.undoAction());
+    }
+  }
+
+  void clearWeightCache() {
+    lastWeighedAt = -1;
+  }
+
+  double getWeight(BalancerClusterState cluster) {
+    boolean hasCandidate = false;
+
+    // Candidate generation is expensive, so for re-weighing generators we will cache
+    // the value for a bit
+    if (System.currentTimeMillis() - lastWeighedAt < WEIGHT_CACHE_TTL.toMillis()) {
+      return lastWeight;
+    } else {
+      hasCandidate = generateCandidate(cluster, true) != BalanceAction.NULL_ACTION;
+      lastWeighedAt = System.currentTimeMillis();
+    }
+
+    if (hasCandidate) {
+      // If this generator has something to do, then it's important
+      lastWeight = CandidateGenerator.MAX_WEIGHT;
+    } else {
+      lastWeight = 0;
+    }
+    return lastWeight;
+  }
+}

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/SlopFixingCandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/SlopFixingCandidateGenerator.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A simple candidate generator that attempts to move regions from the most-loaded servers to the
+ * least-loaded servers.
+ */
+@InterfaceAudience.Private
+final class SlopFixingCandidateGenerator extends RegionPlanConditionalCandidateGenerator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SlopFixingCandidateGenerator.class);
+
+  private final float slop;
+
+  SlopFixingCandidateGenerator(float slop) {
+    this.slop = slop;
+  }
+
+  @Override
+  BalanceAction generateCandidate(BalancerClusterState cluster, boolean isWeighing) {
+    ClusterLoadState cs = new ClusterLoadState(cluster.clusterState);
+    float average = cs.getLoadAverage();
+    int ceiling = (int) Math.ceil(average * (1 + slop));
+    Set<Integer> sloppyServerIndices = new HashSet<>();
+    for (int i = 0; i < cluster.numServers; i++) {
+      int regionCount = cluster.regionsPerServer[i].length;
+      if (regionCount > ceiling) {
+        sloppyServerIndices.add(i);
+      }
+    }
+
+    if (sloppyServerIndices.isEmpty()) {
+      LOG.trace("No action to take because no sloppy servers exist.");
+      return BalanceAction.NULL_ACTION;
+    }
+
+    List<MoveRegionAction> moves = new ArrayList<>();
+    Set<ServerAndLoad> fixedServers = new HashSet<>();
+    for (int sourceServer : sloppyServerIndices) {
+      for (int regionIdx : cluster.regionsPerServer[sourceServer]) {
+        boolean regionFoundMove = false;
+        for (ServerAndLoad serverAndLoad : cs.getServersByLoad().keySet()) {
+          ServerName destinationServer = serverAndLoad.getServerName();
+          int destinationServerIdx = cluster.serversToIndex.get(destinationServer.getAddress());
+          int regionsOnDestination = cluster.regionsPerServer[destinationServerIdx].length;
+          if (regionsOnDestination < average) {
+            MoveRegionAction move =
+              new MoveRegionAction(regionIdx, sourceServer, destinationServerIdx);
+            if (willBeAccepted(cluster, move)) {
+              if (isWeighing) {
+                // Fast exit for weighing candidate
+                return move;
+              }
+              moves.add(move);
+              cluster.doAction(move);
+              regionFoundMove = true;
+              break;
+            }
+          } else {
+            fixedServers.add(serverAndLoad);
+          }
+        }
+        fixedServers.forEach(s -> cs.getServersByLoad().remove(s));
+        fixedServers.clear();
+        if (!regionFoundMove) {
+          LOG.debug("Could not find a destination for region {} from server {}.", regionIdx,
+            sourceServer);
+        }
+        if (cluster.regionsPerServer[sourceServer].length <= ceiling) {
+          break;
+        }
+      }
+    }
+
+    MoveBatchAction batch = new MoveBatchAction(moves);
+    undoBatchAction(cluster, batch);
+    return batch;
+  }
+}

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -170,6 +170,8 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
       return shuffled;
     }, 5, TimeUnit.SECONDS);
 
+  private final BalancerConditionals balancerConditionals = BalancerConditionals.INSTANCE;
+
   /**
    * The constructor that pass a MetricsStochasticBalancer to BaseLoadBalancer to replace its
    * default MetricsBalancer
@@ -223,16 +225,25 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
 
   protected Map<Class<? extends CandidateGenerator>, CandidateGenerator>
     createCandidateGenerators() {
-    Map<Class<? extends CandidateGenerator>, CandidateGenerator> candidateGenerators =
-      new HashMap<>(5);
-    candidateGenerators.put(RandomCandidateGenerator.class, new RandomCandidateGenerator());
-    candidateGenerators.put(LoadCandidateGenerator.class, new LoadCandidateGenerator());
-    candidateGenerators.put(LocalityBasedCandidateGenerator.class, localityCandidateGenerator);
-    candidateGenerators.put(RegionReplicaCandidateGenerator.class,
-      new RegionReplicaCandidateGenerator());
-    candidateGenerators.put(RegionReplicaRackCandidateGenerator.class,
-      new RegionReplicaRackCandidateGenerator());
-    return candidateGenerators;
+    if (balancerConditionals.isReplicaDistributionEnabled()) {
+      Map<Class<? extends CandidateGenerator>, CandidateGenerator> candidateGenerators =
+        new HashMap<>(3);
+      candidateGenerators.put(RandomCandidateGenerator.class, new RandomCandidateGenerator());
+      candidateGenerators.put(LoadCandidateGenerator.class, new LoadCandidateGenerator());
+      candidateGenerators.put(LocalityBasedCandidateGenerator.class, localityCandidateGenerator);
+      return candidateGenerators;
+    } else {
+      Map<Class<? extends CandidateGenerator>, CandidateGenerator> candidateGenerators =
+        new HashMap<>(5);
+      candidateGenerators.put(RandomCandidateGenerator.class, new RandomCandidateGenerator());
+      candidateGenerators.put(LoadCandidateGenerator.class, new LoadCandidateGenerator());
+      candidateGenerators.put(LocalityBasedCandidateGenerator.class, localityCandidateGenerator);
+      candidateGenerators.put(RegionReplicaCandidateGenerator.class,
+        new RegionReplicaCandidateGenerator());
+      candidateGenerators.put(RegionReplicaRackCandidateGenerator.class,
+        new RegionReplicaRackCandidateGenerator());
+      return candidateGenerators;
+    }
   }
 
   protected List<CostFunction> createCostFunctions(Configuration conf) {
@@ -267,6 +278,8 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     localityCost = new ServerLocalityCostFunction(conf);
     rackLocalityCost = new RackLocalityCostFunction(conf);
 
+    // Order is important here. We need to construct conditionals to load candidate generators
+    balancerConditionals.setConf(conf);
     this.candidateGenerators = createCandidateGenerators();
 
     regionReplicaHostCostFunction = new RegionReplicaHostCostFunction(conf);
@@ -340,6 +353,11 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
   }
 
   private boolean areSomeRegionReplicasColocatedOnHost(BalancerClusterState c) {
+    if (!c.hasRegionReplicas || balancerConditionals.isReplicaDistributionEnabled()) {
+      // This check is unnecessary without replicas, or with conditional replica distribution
+      // The balancer will auto-run if conditional replica distribution candidates are available
+      return false;
+    }
     if (c.numHosts >= c.maxReplicas) {
       regionReplicaHostCostFunction.prepare(c);
       double hostCost = Math.abs(regionReplicaHostCostFunction.cost());
@@ -353,6 +371,11 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
   }
 
   private boolean areSomeRegionReplicasColocatedOnRack(BalancerClusterState c) {
+    if (!c.hasRegionReplicas || balancerConditionals.isReplicaDistributionEnabled()) {
+      // This check is unnecessary without replicas, or with conditional replica distribution
+      // The balancer will auto-run if conditional replica distribution candidates are available
+      return false;
+    }
     if (c.numRacks >= c.maxReplicas) {
       regionReplicaRackCostFunction.prepare(c);
       double rackCost = Math.abs(regionReplicaRackCostFunction.cost());
@@ -417,6 +440,11 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
       return true;
     }
 
+    if (balancerConditionals.shouldRunBalancer(cluster)) {
+      LOG.info("Running balancer because conditional candidate generators have important moves");
+      return true;
+    }
+
     double total = 0.0;
     float localSumMultiplier = 0; // in case sumMultiplier is not initialized
     for (CostFunction c : costFunctions) {
@@ -436,14 +464,17 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
         costFunctions);
       LOG.info(
         "{} - skipping load balancing because weighted average imbalance={} <= "
-          + "threshold({}). If you want more aggressive balancing, either lower "
+          + "threshold({}) and conditionals do not have opinionated move candidates. "
+          + "consecutive balancer runs. If you want more aggressive balancing, either lower "
           + "hbase.master.balancer.stochastic.minCostNeedBalance from {} or increase the relative "
           + "multiplier(s) of the specific cost function(s). functionCost={}",
         isByTable ? "Table specific (" + tableName + ")" : "Cluster wide", total / sumMultiplier,
         minCostNeedBalance, minCostNeedBalance, functionCost());
     } else {
-      LOG.info("{} - Calculating plan. may take up to {}ms to complete.",
-        isByTable ? "Table specific (" + tableName + ")" : "Cluster wide", maxRunningTime);
+      LOG.info(
+        "{} - Calculating plan. may take up to {}ms to complete. currentCost={}, targetCost={}",
+        isByTable ? "Table specific (" + tableName + ")" : "Cluster wide", maxRunningTime, total,
+        minCostNeedBalance);
     }
     return !balanced;
   }
@@ -451,7 +482,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
   @RestrictedApi(explanation = "Should only be called in tests", link = "",
       allowedOnPath = ".*(/src/test/.*|StochasticLoadBalancer).java")
   Pair<CandidateGenerator, BalanceAction> nextAction(BalancerClusterState cluster) {
-    CandidateGenerator generator = getRandomGenerator();
+    CandidateGenerator generator = getRandomGenerator(cluster);
     return Pair.newPair(generator, generator.generate(cluster));
   }
 
@@ -460,7 +491,20 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
    * selecting a candidate generator is propotional to the share of cost of all cost functions among
    * all cost functions that benefit from it.
    */
-  protected CandidateGenerator getRandomGenerator() {
+  protected CandidateGenerator getRandomGenerator(BalancerClusterState cluster) {
+    // Prefer conditional generators if they have moves to make
+    if (balancerConditionals.isConditionalBalancingEnabled()) {
+      for (RegionPlanConditional conditional : balancerConditionals.getConditionals()) {
+        List<RegionPlanConditionalCandidateGenerator> generators =
+          conditional.getCandidateGenerators();
+        for (RegionPlanConditionalCandidateGenerator generator : generators) {
+          if (generator.getWeight(cluster) > 0) {
+            return generator;
+          }
+        }
+      }
+    }
+
     List<Class<? extends CandidateGenerator>> generatorClasses = shuffledGeneratorClasses.get();
     List<Double> partialSums = new ArrayList<>(generatorClasses.size());
     double sum = 0.0;
@@ -512,6 +556,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
    * approach the optimal state given enough steps.
    */
   @Override
+  @SuppressWarnings("checkstyle:MethodLength")
   protected List<RegionPlan> balanceTable(TableName tableName,
     Map<ServerName, List<RegionInfo>> loadOfOneTable) {
     // On clusters with lots of HFileLinks or lots of reference files,
@@ -532,6 +577,8 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     long startTime = EnvironmentEdgeManager.currentTime();
 
     initCosts(cluster);
+    balancerConditionals.loadClusterState(cluster);
+    balancerConditionals.clearConditionalWeightCaches();
 
     sumMultiplier = 0;
     for (CostFunction c : costFunctions) {
@@ -579,6 +626,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     final String initFunctionTotalCosts = totalCostsPerFunc();
     // Perform a stochastic walk to see if we can get a good fit.
     long step;
+    boolean planImprovedConditionals = false;
     Map<Class<? extends CandidateGenerator>, Long> generatorToStepCount = new HashMap<>();
     Map<Class<? extends CandidateGenerator>, Long> generatorToApprovedActionCount = new HashMap<>();
     for (step = 0; step < computedMaxSteps; step++) {
@@ -590,16 +638,53 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
         continue;
       }
 
-      cluster.doAction(action);
+      int conditionalViolationsChange = 0;
+      boolean isViolatingConditionals = false;
+      boolean moveImprovedConditionals = false;
+      // Only check conditionals if they are enabled
+      if (balancerConditionals.isConditionalBalancingEnabled()) {
+        // Always accept a conditional generator output. Sometimes conditional generators
+        // may need to make controversial moves in order to break what would otherwise
+        // be a deadlocked situation.
+        // Otherwise, for normal moves, evaluate the action.
+        if (RegionPlanConditionalCandidateGenerator.class.isAssignableFrom(generator.getClass())) {
+          conditionalViolationsChange = -1;
+        } else {
+          conditionalViolationsChange =
+            balancerConditionals.getViolationCountChange(cluster, action);
+          isViolatingConditionals = balancerConditionals.isViolating(cluster, action);
+        }
+        moveImprovedConditionals = conditionalViolationsChange < 0;
+        if (moveImprovedConditionals) {
+          planImprovedConditionals = true;
+        }
+      }
+
+      // Change state and evaluate costs
+      try {
+        cluster.doAction(action);
+      } catch (IllegalStateException | ArrayIndexOutOfBoundsException e) {
+        LOG.warn(
+          "Generator {} produced invalid action! "
+            + "Debug your candidate generator as this is likely a bug, "
+            + "and may cause a balancer deadlock. {}",
+          generator.getClass().getSimpleName(), action, e);
+        continue;
+      }
       updateCostsAndWeightsWithAction(cluster, action);
-      generatorToStepCount.merge(generator.getClass(), 1L, Long::sum);
+      generatorToStepCount.merge(generator.getClass(), action.getStepCount(), Long::sum);
 
       newCost = computeCost(cluster, currentCost);
 
-      // Should this be kept?
-      if (newCost < currentCost) {
+      boolean conditionalsSimilarCostsImproved =
+        (newCost < currentCost && conditionalViolationsChange == 0 && !isViolatingConditionals);
+      // Our first priority is to reduce conditional violations
+      // Our second priority is to reduce balancer cost
+      // change, regardless of cost change
+      if (moveImprovedConditionals || conditionalsSimilarCostsImproved) {
         currentCost = newCost;
-        generatorToApprovedActionCount.merge(generator.getClass(), 1L, Long::sum);
+        generatorToApprovedActionCount.merge(generator.getClass(), action.getStepCount(),
+          Long::sum);
 
         // save for JMX
         curOverallCost = currentCost;
@@ -628,7 +713,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
 
     metricsBalancer.balanceCluster(endTime - startTime);
 
-    if (initCost > currentCost) {
+    if (planImprovedConditionals || (initCost > currentCost)) {
       updateStochasticCosts(tableName, curOverallCost, curFunctionCosts);
       List<RegionPlan> plans = createRegionPlans(cluster);
       LOG.info(
@@ -643,7 +728,8 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     }
     LOG.info(
       "Could not find a better moving plan.  Tried {} different configurations in "
-        + "{} ms, and did not find anything with an imbalance score less than {}",
+        + "{} ms, and did not find anything with an imbalance score less than {} "
+        + "and could not improve conditional violations",
       step, endTime - startTime, initCost / sumMultiplier);
     return null;
   }

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/CandidateGeneratorTestUtil.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/CandidateGeneratorTestUtil.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import static org.apache.hadoop.hbase.master.balancer.StochasticLoadBalancer.MAX_RUNNING_TIME_KEY;
+import static org.apache.hadoop.hbase.master.balancer.StochasticLoadBalancer.MIN_COST_NEED_BALANCE_KEY;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.master.RegionPlan;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class CandidateGeneratorTestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CandidateGeneratorTestUtil.class);
+
+  private CandidateGeneratorTestUtil() {
+  }
+
+  static void runBalancerToExhaustion(Configuration conf,
+    Map<ServerName, List<RegionInfo>> serverToRegions,
+    Set<Function<BalancerClusterState, Boolean>> expectations, float targetMaxBalancerCost) {
+    // Do the full plan. We're testing with a lot of regions
+    conf.setBoolean("hbase.master.balancer.stochastic.runMaxSteps", true);
+    conf.setLong(MAX_RUNNING_TIME_KEY, 15000);
+
+    conf.setFloat(MIN_COST_NEED_BALANCE_KEY, targetMaxBalancerCost);
+
+    Set<TableName> userTablesToBalance =
+      serverToRegions.entrySet().stream().map(Map.Entry::getValue).flatMap(Collection::stream)
+        .map(RegionInfo::getTable).filter(t -> !t.isSystemTable()).collect(Collectors.toSet());
+    BalancerClusterState cluster = createMockBalancerClusterState(serverToRegions);
+    StochasticLoadBalancer stochasticLoadBalancer = buildStochasticLoadBalancer(cluster, conf);
+    printClusterDistribution(cluster, 0);
+    int balancerRuns = 0;
+    int actionsTaken = 0;
+    long balancingMillis = 0;
+    boolean isBalanced = false;
+    while (!isBalanced) {
+      balancerRuns++;
+      if (balancerRuns > 1000) {
+        throw new RuntimeException("Balancer failed to find balance & meet expectations");
+      }
+      long start = System.currentTimeMillis();
+      List<RegionPlan> regionPlans =
+        stochasticLoadBalancer.balanceCluster(partitionRegionsByTable(serverToRegions));
+      balancingMillis += System.currentTimeMillis() - start;
+      actionsTaken++;
+      if (regionPlans != null) {
+        // Apply all plans to serverToRegions
+        for (RegionPlan rp : regionPlans) {
+          ServerName source = rp.getSource();
+          ServerName dest = rp.getDestination();
+          RegionInfo region = rp.getRegionInfo();
+
+          // Update serverToRegions
+          serverToRegions.get(source).remove(region);
+          serverToRegions.get(dest).add(region);
+          actionsTaken++;
+        }
+
+        // Now rebuild cluster and balancer from updated serverToRegions
+        cluster = createMockBalancerClusterState(serverToRegions);
+        stochasticLoadBalancer = buildStochasticLoadBalancer(cluster, conf);
+      }
+      printClusterDistribution(cluster, actionsTaken);
+      isBalanced = true;
+      for (Function<BalancerClusterState, Boolean> condition : expectations) {
+        // Check if we've met all expectations for the candidate generator
+        if (!condition.apply(cluster)) {
+          isBalanced = false;
+          break;
+        }
+      }
+      if (isBalanced) { // Check if the balancer thinks we're done too
+        LOG.info("All balancer conditions passed. Checking if balancer thinks it's done.");
+        if (stochasticLoadBalancer.needsBalance(HConstants.ENSEMBLE_TABLE_NAME, cluster)) {
+          LOG.info("Balancer would still like to run");
+          isBalanced = false;
+        } else {
+          LOG.info("Balancer is done");
+        }
+      }
+    }
+    LOG.info("Balancing took {}sec", Duration.ofMillis(balancingMillis).toMinutes());
+  }
+
+  /**
+   * Prints the current cluster distribution of regions per table per server
+   */
+  static void printClusterDistribution(BalancerClusterState cluster, long actionsTaken) {
+    LOG.info("=== Cluster Distribution after {} balancer actions taken ===", actionsTaken);
+
+    for (int i = 0; i < cluster.numServers; i++) {
+      int[] regions = cluster.regionsPerServer[i];
+      int regionCount = (regions == null) ? 0 : regions.length;
+
+      LOG.info("Server {}: {} regions", cluster.servers[i].getServerName(), regionCount);
+
+      if (regionCount > 0) {
+        Map<TableName, Integer> tableRegionCounts = new HashMap<>();
+
+        for (int regionIndex : regions) {
+          RegionInfo regionInfo = cluster.regions[regionIndex];
+          TableName tableName = regionInfo.getTable();
+          tableRegionCounts.put(tableName, tableRegionCounts.getOrDefault(tableName, 0) + 1);
+        }
+
+        tableRegionCounts
+          .forEach((table, count) -> LOG.info("  - Table {}: {} regions", table, count));
+      }
+    }
+
+    LOG.info("===========================================");
+  }
+
+  /**
+   * Partitions the given serverToRegions map by table The tables are derived from the RegionInfo
+   * objects found in serverToRegions.
+   * @param serverToRegions The map of servers to their assigned regions.
+   * @return A map of tables to their server-to-region assignments.
+   */
+  public static Map<TableName, Map<ServerName, List<RegionInfo>>>
+    partitionRegionsByTable(Map<ServerName, List<RegionInfo>> serverToRegions) {
+
+    // First, gather all tables from the regions
+    Set<TableName> allTables = new HashSet<>();
+    for (List<RegionInfo> regions : serverToRegions.values()) {
+      for (RegionInfo region : regions) {
+        allTables.add(region.getTable());
+      }
+    }
+
+    Map<TableName, Map<ServerName, List<RegionInfo>>> tablesToServersToRegions = new HashMap<>();
+
+    // Initialize each table with all servers mapped to empty lists
+    for (TableName table : allTables) {
+      Map<ServerName, List<RegionInfo>> serverMap = new HashMap<>();
+      for (ServerName server : serverToRegions.keySet()) {
+        serverMap.put(server, new ArrayList<>());
+      }
+      tablesToServersToRegions.put(table, serverMap);
+    }
+
+    // Distribute regions to their respective tables
+    for (Map.Entry<ServerName, List<RegionInfo>> serverAndRegions : serverToRegions.entrySet()) {
+      ServerName server = serverAndRegions.getKey();
+      List<RegionInfo> regions = serverAndRegions.getValue();
+
+      for (RegionInfo region : regions) {
+        TableName regionTable = region.getTable();
+        // Now we know for sure regionTable is in allTables
+        Map<ServerName, List<RegionInfo>> tableServerMap =
+          tablesToServersToRegions.get(regionTable);
+        tableServerMap.get(server).add(region);
+      }
+    }
+
+    return tablesToServersToRegions;
+  }
+
+  static StochasticLoadBalancer buildStochasticLoadBalancer(BalancerClusterState cluster,
+    Configuration conf) {
+    StochasticLoadBalancer stochasticLoadBalancer =
+      new StochasticLoadBalancer(new DummyMetricsStochasticBalancer());
+    stochasticLoadBalancer.setClusterInfoProvider(new DummyClusterInfoProvider(conf));
+    stochasticLoadBalancer.loadConf(conf);
+    stochasticLoadBalancer.initCosts(cluster);
+    return stochasticLoadBalancer;
+  }
+
+  static BalancerClusterState
+    createMockBalancerClusterState(Map<ServerName, List<RegionInfo>> serverToRegions) {
+    return new BalancerClusterState(serverToRegions, null, null, null, null);
+  }
+
+  /**
+   * Validates that each replica is isolated from its others. Ensures that no server hosts more than
+   * one replica of the same region (i.e., regions with identical start and end keys).
+   * @param cluster The current state of the cluster.
+   * @return true if all replicas are properly isolated, false otherwise.
+   */
+  static boolean areAllReplicasDistributed(BalancerClusterState cluster) {
+    // Iterate over each server
+    for (int[] regionsPerServer : cluster.regionsPerServer) {
+      if (regionsPerServer == null || regionsPerServer.length == 0) {
+        continue; // Skip empty servers
+      }
+
+      Set<DistributeReplicasConditional.ReplicaKey> foundKeys = new HashSet<>();
+      for (int regionIndex : regionsPerServer) {
+        RegionInfo regionInfo = cluster.regions[regionIndex];
+        DistributeReplicasConditional.ReplicaKey replicaKey =
+          new DistributeReplicasConditional.ReplicaKey(regionInfo);
+        if (foundKeys.contains(replicaKey)) {
+          // Violation: Multiple replicas of the same region on the same server
+          LOG.warn("Replica isolation violated: one server hosts multiple replicas of key [{}].",
+            generateRegionKey(regionInfo));
+          return false;
+        }
+
+        foundKeys.add(replicaKey);
+      }
+    }
+
+    LOG.info(
+      "Replica isolation validation passed: No server hosts multiple replicas of the same region.");
+    return true;
+  }
+
+  /**
+   * Generates a unique key for a region based on its start and end keys. This method ensures that
+   * regions with identical start and end keys have the same key.
+   * @param regionInfo The RegionInfo object.
+   * @return A string representing the unique key of the region.
+   */
+  private static String generateRegionKey(RegionInfo regionInfo) {
+    // Using Base64 encoding for byte arrays to ensure uniqueness and readability
+    String startKey = Base64.getEncoder().encodeToString(regionInfo.getStartKey());
+    String endKey = Base64.getEncoder().encodeToString(regionInfo.getEndKey());
+
+    return regionInfo.getTable().getNameAsString() + ":" + startKey + ":" + endKey;
+  }
+
+}

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBalancerConditionals.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBalancerConditionals.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(SmallTests.class)
+public class TestBalancerConditionals extends BalancerTestBase {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestBalancerConditionals.class);
+
+  private BalancerConditionals balancerConditionals;
+  private BalancerClusterState mockCluster;
+
+  @Before
+  public void setUp() {
+    balancerConditionals = BalancerConditionals.INSTANCE;
+    mockCluster = mockCluster(new int[] { 0, 1, 2 });
+  }
+
+  @Test
+  public void testDefaultConfiguration() {
+    Configuration conf = new Configuration();
+    balancerConditionals.setConf(conf);
+    balancerConditionals.loadClusterState(mockCluster);
+
+    assertEquals("No conditionals should be loaded by default", 0,
+      balancerConditionals.getConditionalClasses().size());
+  }
+
+  @Test
+  public void testCustomConditionalsViaConfiguration() {
+    Configuration conf = new Configuration();
+    conf.set(BalancerConditionals.ADDITIONAL_CONDITIONALS_KEY,
+      DistributeReplicasConditional.class.getName());
+
+    balancerConditionals.setConf(conf);
+    balancerConditionals.loadClusterState(mockCluster);
+
+    assertTrue("Custom conditionals should be loaded",
+      balancerConditionals.shouldSkipSloppyServerEvaluation());
+  }
+
+  @Test
+  public void testInvalidCustomConditionalClass() {
+    Configuration conf = new Configuration();
+    conf.set(BalancerConditionals.ADDITIONAL_CONDITIONALS_KEY, "java.lang.String");
+
+    balancerConditionals.setConf(conf);
+    balancerConditionals.loadClusterState(mockCluster);
+
+    assertEquals("Invalid classes should not be loaded as conditionals", 0,
+      balancerConditionals.getConditionalClasses().size());
+  }
+
+}

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestLargeClusterBalancingConditionalReplicaDistribution.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestLargeClusterBalancingConditionalReplicaDistribution.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import static org.apache.hadoop.hbase.master.balancer.CandidateGeneratorTestUtil.runBalancerToExhaustion;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category(MediumTests.class)
+public class TestLargeClusterBalancingConditionalReplicaDistribution {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestLargeClusterBalancingConditionalReplicaDistribution.class);
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestLargeClusterBalancingConditionalReplicaDistribution.class);
+
+  private static final int NUM_SERVERS = 1000;
+  private static final int NUM_REGIONS = 20_000;
+  private static final int NUM_REPLICAS = 3;
+  private static final int NUM_TABLES = 100;
+
+  private static final ServerName[] servers = new ServerName[NUM_SERVERS];
+  private static final Map<ServerName, List<RegionInfo>> serverToRegions = new HashMap<>();
+
+  @BeforeClass
+  public static void setup() {
+    // Initialize servers
+    for (int i = 0; i < NUM_SERVERS; i++) {
+      servers[i] = ServerName.valueOf("server" + i, i, System.currentTimeMillis());
+      serverToRegions.put(servers[i], new ArrayList<>());
+    }
+
+    // Create primary regions and their replicas
+    List<RegionInfo> allRegions = new ArrayList<>();
+    for (int i = 0; i < NUM_REGIONS; i++) {
+      TableName tableName = getTableName(i);
+      // Define startKey and endKey for the region
+      byte[] startKey = Bytes.toBytes(i);
+      byte[] endKey = Bytes.toBytes(i + 1);
+
+      // Create 3 replicas for each primary region
+      for (int replicaId = 0; replicaId < NUM_REPLICAS; replicaId++) {
+        RegionInfo regionInfo = RegionInfoBuilder.newBuilder(tableName).setStartKey(startKey)
+          .setEndKey(endKey).setReplicaId(replicaId).build();
+        allRegions.add(regionInfo);
+      }
+    }
+
+    // Assign all regions to one server
+    for (RegionInfo regionInfo : allRegions) {
+      serverToRegions.get(servers[0]).add(regionInfo);
+    }
+  }
+
+  private static TableName getTableName(int i) {
+    return TableName.valueOf("userTable" + i % NUM_TABLES);
+  }
+
+  @Test
+  public void testReplicaDistribution() {
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(BalancerConditionals.DISTRIBUTE_REPLICAS_KEY, true);
+    conf.setBoolean(DistributeReplicasConditional.TEST_MODE_ENABLED_KEY, true);
+    conf.setBoolean(DistributeReplicasConditional.CACHE_REPLICA_KEYS_KEY, true);
+    conf.setLong("hbase.master.balancer.stochastic.maxRunningTime", 30_000);
+
+    // turn off replica cost functions
+    conf.setLong("hbase.master.balancer.stochastic.regionReplicaRackCostKey", 0);
+    conf.setLong("hbase.master.balancer.stochastic.regionReplicaHostCostKey", 0);
+
+    runBalancerToExhaustion(conf, serverToRegions,
+      Set.of(CandidateGeneratorTestUtil::areAllReplicasDistributed), 10.0f);
+    LOG.info("Meta table and system table regions are successfully isolated, "
+      + "meanwhile region replicas are appropriately distributed across RegionServers.");
+  }
+}

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerHeterogeneousCost.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerHeterogeneousCost.java
@@ -245,7 +245,7 @@ public class TestStochasticLoadBalancerHeterogeneousCost extends StochasticBalan
     }
 
     @Override
-    protected CandidateGenerator getRandomGenerator() {
+    protected CandidateGenerator getRandomGenerator(BalancerClusterState cluster) {
       return fairRandomCandidateGenerator;
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/BalancerConditionalsTestUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/BalancerConditionalsTestUtil.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.quotas.QuotaUtil;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
+
+public final class BalancerConditionalsTestUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BalancerConditionalsTestUtil.class);
+
+  private BalancerConditionalsTestUtil() {
+  }
+
+  static byte[][] generateSplits(int numRegions) {
+    byte[][] splitKeys = new byte[numRegions - 1][];
+    for (int i = 0; i < numRegions - 1; i++) {
+      splitKeys[i] =
+        Bytes.toBytes(String.format("%09d", (i + 1) * (Integer.MAX_VALUE / numRegions)));
+    }
+    return splitKeys;
+  }
+
+  static void printRegionLocations(Connection connection) throws IOException {
+    Admin admin = connection.getAdmin();
+
+    // Get all table names in the cluster
+    Set<TableName> tableNames = admin.listTableDescriptors(true).stream()
+      .map(TableDescriptor::getTableName).collect(Collectors.toSet());
+
+    // Group regions by server
+    Map<ServerName, Map<TableName, List<RegionInfo>>> serverToRegions =
+      admin.getClusterMetrics().getLiveServerMetrics().keySet().stream()
+        .collect(Collectors.toMap(server -> server, server -> {
+          try {
+            return listRegionsByTable(connection, server, tableNames);
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }));
+
+    // Pretty print region locations
+    StringBuilder regionLocationOutput = new StringBuilder();
+    regionLocationOutput.append("Pretty printing region locations...\n");
+    serverToRegions.forEach((server, tableRegions) -> {
+      regionLocationOutput.append("Server: " + server.getServerName() + "\n");
+      tableRegions.forEach((table, regions) -> {
+        if (regions.isEmpty()) {
+          return;
+        }
+        regionLocationOutput.append("  Table: " + table.getNameAsString() + "\n");
+        regions.forEach(region -> regionLocationOutput
+          .append(String.format("    Region: %s, start: %s, end: %s, replica: %s\n",
+            region.getEncodedName(), Bytes.toString(region.getStartKey()),
+            Bytes.toString(region.getEndKey()), region.getReplicaId())));
+      });
+    });
+    LOG.info(regionLocationOutput.toString());
+  }
+
+  private static Map<TableName, List<RegionInfo>> listRegionsByTable(Connection connection,
+    ServerName server, Set<TableName> tableNames) throws IOException {
+    Admin admin = connection.getAdmin();
+
+    // Find regions for each table
+    return tableNames.stream().collect(Collectors.toMap(tableName -> tableName, tableName -> {
+      List<RegionInfo> allRegions = null;
+      try {
+        allRegions = admin.getRegions(server);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return allRegions.stream().filter(region -> region.getTable().equals(tableName))
+        .collect(Collectors.toList());
+    }));
+  }
+
+  static void validateReplicaDistribution(Connection connection, TableName tableName,
+    boolean shouldBeDistributed) {
+    Map<ServerName, List<RegionInfo>> serverToRegions = null;
+    try {
+      serverToRegions = connection.getRegionLocator(tableName).getAllRegionLocations().stream()
+        .collect(Collectors.groupingBy(location -> location.getServerName(),
+          Collectors.mapping(location -> location.getRegion(), Collectors.toList())));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    if (shouldBeDistributed) {
+      // Ensure no server hosts more than one replica of any region
+      for (Map.Entry<ServerName, List<RegionInfo>> serverAndRegions : serverToRegions.entrySet()) {
+        List<RegionInfo> regionInfos = serverAndRegions.getValue();
+        Set<byte[]> startKeys = new HashSet<>();
+        for (RegionInfo regionInfo : regionInfos) {
+          // each region should have a distinct start key
+          assertFalse(
+            "Each region should have its own start key, "
+              + "demonstrating it is not a replica of any others on this host",
+            startKeys.contains(regionInfo.getStartKey()));
+          startKeys.add(regionInfo.getStartKey());
+        }
+      }
+    } else {
+      // Ensure all replicas are on the same server
+      assertEquals("All regions should share one server", 1, serverToRegions.size());
+    }
+  }
+
+  static void validateRegionLocations(Map<TableName, Set<ServerName>> tableToServers,
+    TableName productTableName, boolean shouldBeBalanced) {
+    ServerName metaServer =
+      tableToServers.get(TableName.META_TABLE_NAME).stream().findFirst().orElseThrow();
+    ServerName quotaServer =
+      tableToServers.get(QuotaUtil.QUOTA_TABLE_NAME).stream().findFirst().orElseThrow();
+    Set<ServerName> productServers = tableToServers.get(productTableName);
+
+    if (shouldBeBalanced) {
+      for (ServerName server : productServers) {
+        assertNotEquals("Meta table and product table should not share servers", server,
+          metaServer);
+        assertNotEquals("Quota table and product table should not share servers", server,
+          quotaServer);
+      }
+      assertNotEquals("The meta server and quotas server should be different", metaServer,
+        quotaServer);
+    } else {
+      for (ServerName server : productServers) {
+        assertEquals("Meta table and product table must share servers", server, metaServer);
+        assertEquals("Quota table and product table must share servers", server, quotaServer);
+      }
+      assertEquals("The meta server and quotas server must be the same", metaServer, quotaServer);
+    }
+  }
+
+  static Map<TableName, Set<ServerName>> getTableToServers(Connection connection,
+    Set<TableName> tableNames) {
+    return tableNames.stream().collect(Collectors.toMap(t -> t, t -> {
+      try {
+        return connection.getRegionLocator(t).getAllRegionLocations().stream()
+          .map(HRegionLocation::getServerName).collect(Collectors.toSet());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }));
+  }
+
+  @FunctionalInterface
+  interface AssertionRunnable {
+    void run() throws AssertionError;
+  }
+
+  static void validateAssertionsWithRetries(HBaseTestingUtil testUtil, boolean runBalancerOnFailure,
+    AssertionRunnable assertion) {
+    validateAssertionsWithRetries(testUtil, runBalancerOnFailure, ImmutableSet.of(assertion));
+  }
+
+  static void validateAssertionsWithRetries(HBaseTestingUtil testUtil, boolean runBalancerOnFailure,
+    Set<AssertionRunnable> assertions) {
+    int maxAttempts = 50;
+    for (int i = 0; i < maxAttempts; i++) {
+      try {
+        for (AssertionRunnable assertion : assertions) {
+          assertion.run();
+        }
+      } catch (AssertionError e) {
+        if (i == maxAttempts - 1) {
+          throw e;
+        }
+        try {
+          LOG.warn("Failed to validate region locations. Will retry", e);
+          Thread.sleep(1000);
+          BalancerConditionalsTestUtil.printRegionLocations(testUtil.getConnection());
+          if (runBalancerOnFailure) {
+            testUtil.getAdmin().balance();
+          }
+          Thread.sleep(1000);
+        } catch (Exception ex) {
+          throw new RuntimeException(ex);
+        }
+      }
+    }
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestReplicaDistributionBalancerConditional.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestReplicaDistributionBalancerConditional.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.balancer;
+
+import static org.apache.hadoop.hbase.master.balancer.BalancerConditionalsTestUtil.validateAssertionsWithRetries;
+
+import java.util.List;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category(LargeTests.class)
+public class TestReplicaDistributionBalancerConditional {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestReplicaDistributionBalancerConditional.class);
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestReplicaDistributionBalancerConditional.class);
+  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private static final int REPLICAS = 3;
+  private static final int NUM_SERVERS = REPLICAS;
+  private static final int REGIONS_PER_SERVER = 5;
+
+  @Before
+  public void setUp() throws Exception {
+    TEST_UTIL.getConfiguration().setBoolean(BalancerConditionals.DISTRIBUTE_REPLICAS_KEY, true);
+    TEST_UTIL.getConfiguration().setBoolean(DistributeReplicasConditional.TEST_MODE_ENABLED_KEY,
+      true);
+    TEST_UTIL.getConfiguration()
+      .setBoolean(ServerRegionReplicaUtil.REGION_REPLICA_REPLICATION_CONF_KEY, true);
+    TEST_UTIL.getConfiguration().setLong(HConstants.HBASE_BALANCER_PERIOD, 1000L);
+    TEST_UTIL.getConfiguration().setBoolean("hbase.master.balancer.stochastic.runMaxSteps", true);
+
+    // turn off replica cost functions
+    TEST_UTIL.getConfiguration()
+      .setLong("hbase.master.balancer.stochastic.regionReplicaRackCostKey", 0);
+    TEST_UTIL.getConfiguration()
+      .setLong("hbase.master.balancer.stochastic.regionReplicaHostCostKey", 0);
+
+    TEST_UTIL.startMiniCluster(NUM_SERVERS);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testReplicaDistribution() throws Exception {
+    Connection connection = TEST_UTIL.getConnection();
+    Admin admin = connection.getAdmin();
+
+    // Create a "replicated_table" with region replicas
+    TableName replicatedTableName = TableName.valueOf("replicated_table");
+    TableDescriptor replicatedTableDescriptor =
+      TableDescriptorBuilder.newBuilder(replicatedTableName)
+        .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(Bytes.toBytes("0")).build())
+        .setRegionReplication(REPLICAS).build();
+    admin.createTable(replicatedTableDescriptor,
+      BalancerConditionalsTestUtil.generateSplits(REGIONS_PER_SERVER * NUM_SERVERS));
+
+    // Pause the balancer
+    admin.balancerSwitch(false, true);
+
+    // Collect all region replicas and place them on one RegionServer
+    List<RegionInfo> allRegions = admin.getRegions(replicatedTableName);
+    String targetServer =
+      TEST_UTIL.getHBaseCluster().getRegionServer(0).getServerName().getServerName();
+
+    for (RegionInfo region : allRegions) {
+      admin.move(region.getEncodedNameAsBytes(), Bytes.toBytes(targetServer));
+    }
+
+    BalancerConditionalsTestUtil.printRegionLocations(TEST_UTIL.getConnection());
+    validateAssertionsWithRetries(TEST_UTIL, false, () -> BalancerConditionalsTestUtil
+      .validateReplicaDistribution(connection, replicatedTableName, false));
+
+    // Unpause the balancer and trigger balancing
+    admin.balancerSwitch(true, true);
+    admin.balance();
+
+    validateAssertionsWithRetries(TEST_UTIL, true, () -> BalancerConditionalsTestUtil
+      .validateReplicaDistribution(connection, replicatedTableName, true));
+    BalancerConditionalsTestUtil.printRegionLocations(TEST_UTIL.getConnection());
+  }
+}


### PR DESCRIPTION
I'll rebase this on apache/master once https://github.com/apache/hbase/pull/6598, https://github.com/HubSpot/hbase/pull/135, and https://github.com/HubSpot/hbase/pull/136 have shipped

Big PR here: it adds the balancer conditional framework and our first conditional implementation: replica distribution. This is an improvement on existing cost-based replica distribution for reasons that I'll dig into further. See my design doc [here](https://docs.google.com/document/d/1jA8Ghs86v7b-53j5DcsdbPnOXxbHjewkIBFi1E4S1pY/edit?usp=sharing).

You can enable conditional replica distribution via `hbase.master.balancer.stochastic.conditionals.distributeReplicas`: set this to true to enable the feature.

### Improvements on Replica Balancing

**Primary replica balancing squashes all other considerations**. The default weight for one of the several cost functions that factor into primary replica balancing is 100,000. Meanwhile the default read request cost is 5. The result is that the load balancer, OOTB, basically doesn't care about balancing actual load. To solve this, you can either set primary replica balancing costs to zero, which is fine if you don't use read replicas, or — if you do use read replicas — maybe you can produce a magic incantation of configurations that work _just_ right, until your needs change. Conditionals provide an alternative which works much more cleanly in relation to all of the other considerations that you would like your balancer to have.

**Replica cost functions don't balance secondary replicas effectively**. While they'll calculate imbalance costs necessary to balance primary replicas away from secondary replicas, there is no sufficient mechanism in the existing cost functions to distribute secondary replicas appropriately. So using >2 replicas on a table has a pretty dubious value proposition. On the other hand, this conditional implementation will ensure that secondary replicas are distributed to the greatest extent that the cluster allows. Even on a relatively tiny minicluster test I was unable to demonstrate that cost-based replica balancing could distribute a 3 replica table perfectly:
![cf1](https://github.com/user-attachments/assets/1dccc536-eaa0-4775-878b-5a50d16d8ddf)
![cf2](https://github.com/user-attachments/assets/cc70264f-d10a-473e-b726-4ef85ec4ea4e)

**….omitting the meaningless snapshots between 4 and 27…**

![cf28](https://github.com/user-attachments/assets/bc20781d-c166-4b07-910a-bec5515bfd5a)

Meanwhile, conditional based replica balancing solved this imbalance effectively:
![bc1](https://github.com/user-attachments/assets/6d9248e6-64ec-4b0d-b12f-e064901e77f8)
![bc2](https://github.com/user-attachments/assets/d07c4803-b249-4d02-be54-ce0439c92f96)
![bc3](https://github.com/user-attachments/assets/229d1520-a6ef-4f61-83c9-b32dd2e7671d)
![bc4](https://github.com/user-attachments/assets/c0bd874a-8ac0-4882-8ffb-e4b0be59ba20)
![bc5](https://github.com/user-attachments/assets/a2f0e094-a3df-415f-9be0-cbb99cdb7494)

### Testing

I've written a minicluster test to validate that conditional replica balancing works on a small cluster locally, and I've written a larger scale test that mocks the StochasticLoadBalancer in hbase-balancer. This test validates that conditional balancing performance is acceptable; even at a huge scale, even with default balancer costs (which other large scale cost-based replica balancing tests have had to compromise), and even with strict consideration for secondary replicas

cc @ndimiduk 