### PR TITLE
HubSpot Backport: HBASE-29351: Quotas: adaptive wait intervals (not yet merged upstream)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/FeedbackAdaptiveRateLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/FeedbackAdaptiveRateLimiter.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.quotas;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
+
+import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
+import org.apache.hbase.thirdparty.com.google.common.util.concurrent.AtomicDouble;
+
+/**
+ * This rate limiter works much like the FixedIntervalRateLimiter, except that:
+ * <ol>
+ * <li>it will increase backpressure on multithreaded clients</li>
+ * <li>it will allow over-subscription to hit consistent, full allowance utilization</li>
+ * </ol>
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public class FeedbackAdaptiveRateLimiter extends RateLimiter {
+
+  /**
+   * Amount to increase the backoff multiplier when contention is detected per refill interval.
+   */
+  public static final String FEEDBACK_ADAPTIVE_BACKOFF_MULTIPLIER_INCREMENT =
+    "hbase.quota.rate.limiter.feedback.adaptive.backoff.multiplier.increment";
+  public static final double DEFAULT_BACKOFF_MULTIPLIER_INCREMENT = 0.0001;
+
+  /**
+   * Amount to decrease the backoff multiplier when no contention is detected per refill interval.
+   */
+  public static final String FEEDBACK_ADAPTIVE_BACKOFF_MULTIPLIER_DECREMENT =
+    "hbase.quota.rate.limiter.feedback.adaptive.backoff.multiplier.decrement";
+  public static final double DEFAULT_BACKOFF_MULTIPLIER_DECREMENT = 0.0001;
+
+  /**
+   * Maximum ceiling for the backoff multiplier to avoid unbounded waits.
+   */
+  public static final String FEEDBACK_ADAPTIVE_MAX_BACKOFF_MULTIPLIER =
+    "hbase.quota.rate.limiter.feedback.adaptive.max.backoff.multiplier";
+  public static final double DEFAULT_MAX_BACKOFF_MULTIPLIER = 10.0;
+
+  /**
+   * Amount to increase the oversubscription proportion when utilization is below target.
+   */
+  public static final String FEEDBACK_ADAPTIVE_OVERSUBSCRIPTION_INCREMENT =
+    "hbase.quota.rate.limiter.feedback.adaptive.oversubscription.increment";
+  public static final double DEFAULT_OVERSUBSCRIPTION_INCREMENT = 0.00001;
+
+  /**
+   * Amount to decrease the oversubscription proportion when utilization exceeds target.
+   */
+  public static final String FEEDBACK_ADAPTIVE_OVERSUBSCRIPTION_DECREMENT =
+    "hbase.quota.rate.limiter.feedback.adaptive.oversubscription.decrement";
+  public static final double DEFAULT_OVERSUBSCRIPTION_DECREMENT = 0.00001;
+
+  /**
+   * Maximum ceiling for oversubscription to prevent unbounded bursts.
+   */
+  public static final String FEEDBACK_ADAPTIVE_MAX_OVERSUBSCRIPTION =
+    "hbase.quota.rate.limiter.feedback.adaptive.max.oversubscription";
+  public static final double DEFAULT_MAX_OVERSUBSCRIPTION = 0.05;
+
+  /**
+   * Acceptable deviation around full utilization (1.0) for adjusting oversubscription.
+   */
+  public static final String FEEDBACK_ADAPTIVE_UTILIZATION_ERROR_BUDGET =
+    "hbase.quota.rate.limiter.feedback.adaptive.utilization.error.budget";
+  public static final double DEFAULT_UTILIZATION_ERROR_BUDGET = 0.025;
+
+  private static final int WINDOW_TIME_MS = 60_000;
+
+  public static class FeedbackAdaptiveRateLimiterFactory {
+
+    private final long refillInterval;
+    private final double backoffMultiplierIncrement;
+    private final double backoffMultiplierDecrement;
+    private final double maxBackoffMultiplier;
+    private final double oversubscriptionIncrement;
+    private final double oversubscriptionDecrement;
+    private final double maxOversubscription;
+    private final double utilizationErrorBudget;
+
+    public FeedbackAdaptiveRateLimiterFactory(Configuration conf) {
+      refillInterval = conf.getLong(FixedIntervalRateLimiter.RATE_LIMITER_REFILL_INTERVAL_MS,
+        RateLimiter.DEFAULT_TIME_UNIT);
+
+      maxBackoffMultiplier =
+        conf.getDouble(FEEDBACK_ADAPTIVE_MAX_BACKOFF_MULTIPLIER, DEFAULT_MAX_BACKOFF_MULTIPLIER);
+
+      backoffMultiplierIncrement = conf.getDouble(FEEDBACK_ADAPTIVE_BACKOFF_MULTIPLIER_INCREMENT,
+        DEFAULT_BACKOFF_MULTIPLIER_INCREMENT);
+      backoffMultiplierDecrement = conf.getDouble(FEEDBACK_ADAPTIVE_BACKOFF_MULTIPLIER_DECREMENT,
+        DEFAULT_BACKOFF_MULTIPLIER_DECREMENT);
+
+      oversubscriptionIncrement = conf.getDouble(FEEDBACK_ADAPTIVE_OVERSUBSCRIPTION_INCREMENT,
+        DEFAULT_OVERSUBSCRIPTION_INCREMENT);
+      oversubscriptionDecrement = conf.getDouble(FEEDBACK_ADAPTIVE_OVERSUBSCRIPTION_DECREMENT,
+        DEFAULT_OVERSUBSCRIPTION_DECREMENT);
+
+      maxOversubscription =
+        conf.getDouble(FEEDBACK_ADAPTIVE_MAX_OVERSUBSCRIPTION, DEFAULT_MAX_OVERSUBSCRIPTION);
+      utilizationErrorBudget = conf.getDouble(FEEDBACK_ADAPTIVE_UTILIZATION_ERROR_BUDGET,
+        DEFAULT_UTILIZATION_ERROR_BUDGET);
+    }
+
+    public FeedbackAdaptiveRateLimiter create() {
+      return new FeedbackAdaptiveRateLimiter(refillInterval, backoffMultiplierIncrement,
+        backoffMultiplierDecrement, maxBackoffMultiplier, oversubscriptionIncrement,
+        oversubscriptionDecrement, maxOversubscription, utilizationErrorBudget);
+    }
+  }
+
+  private long nextRefillTime = -1L;
+  private final long refillInterval;
+  private final double backoffMultiplierIncrement;
+  private final double backoffMultiplierDecrement;
+  private final double maxBackoffMultiplier;
+  private final double oversubscriptionIncrement;
+  private final double oversubscriptionDecrement;
+  private final double maxOversubscription;
+  private final double minTargetUtilization;
+  private final double maxTargetUtilization;
+
+  // Adaptive backoff state
+  private final AtomicDouble currentBackoffMultiplier = new AtomicDouble(1.0);
+  private volatile boolean hadContentionThisInterval = false;
+
+  // Over-subscription proportion state
+  private final AtomicDouble oversubscriptionProportion = new AtomicDouble(0.0);
+
+  // EWMA tracking
+  private final double emaAlpha;
+  private volatile double utilizationEma = 0.0;
+  private final AtomicLong lastIntervalConsumed;
+
+  FeedbackAdaptiveRateLimiter(long refillInterval, double backoffMultiplierIncrement,
+    double backoffMultiplierDecrement, double maxBackoffMultiplier,
+    double oversubscriptionIncrement, double oversubscriptionDecrement, double maxOversubscription,
+    double utilizationErrorBudget) {
+    super();
+    Preconditions.checkArgument(getTimeUnitInMillis() >= refillInterval, String.format(
+      "Refill interval %s must be ≤ TimeUnit millis %s", refillInterval, getTimeUnitInMillis()));
+
+    Preconditions.checkArgument(backoffMultiplierIncrement > 0.0,
+      String.format("Backoff multiplier increment %s must be > 0.0", backoffMultiplierIncrement));
+    Preconditions.checkArgument(backoffMultiplierDecrement > 0.0,
+      String.format("Backoff multiplier decrement %s must be > 0.0", backoffMultiplierDecrement));
+    Preconditions.checkArgument(maxBackoffMultiplier > 1.0,
+      String.format("Max backoff multiplier %s must be > 1.0", maxBackoffMultiplier));
+    Preconditions.checkArgument(utilizationErrorBudget > 0.0 && utilizationErrorBudget <= 1.0,
+      String.format("Utilization error budget %s must be between 0.0 and 1.0",
+        utilizationErrorBudget));
+
+    this.refillInterval = refillInterval;
+    this.backoffMultiplierIncrement = backoffMultiplierIncrement;
+    this.backoffMultiplierDecrement = backoffMultiplierDecrement;
+    this.maxBackoffMultiplier = maxBackoffMultiplier;
+    this.oversubscriptionIncrement = oversubscriptionIncrement;
+    this.oversubscriptionDecrement = oversubscriptionDecrement;
+    this.maxOversubscription = maxOversubscription;
+    this.minTargetUtilization = 1.0 - utilizationErrorBudget;
+    this.maxTargetUtilization = 1.0 + utilizationErrorBudget;
+
+    this.emaAlpha = refillInterval / (double) (WINDOW_TIME_MS + refillInterval);
+    this.lastIntervalConsumed = new AtomicLong(0);
+  }
+
+  @Override
+  public long refill(long limit) {
+    final long now = EnvironmentEdgeManager.currentTime();
+    if (nextRefillTime == -1) {
+      nextRefillTime = now + refillInterval;
+      hadContentionThisInterval = false;
+      return getOversubscribedLimit(limit);
+    }
+    if (now < nextRefillTime) {
+      return 0;
+    }
+    long diff = refillInterval + now - nextRefillTime;
+    long refills = diff / refillInterval;
+    nextRefillTime = now + refillInterval;
+
+    long intendedUsage = getRefillIntervalAdjustedLimit(limit);
+    if (intendedUsage > 0) {
+      long consumed = lastIntervalConsumed.get();
+      if (consumed > 0) {
+        double util = (double) consumed / intendedUsage;
+        utilizationEma = emaAlpha * util + (1.0 - emaAlpha) * utilizationEma;
+      }
+    }
+
+    if (hadContentionThisInterval) {
+      currentBackoffMultiplier.set(Math
+        .min(currentBackoffMultiplier.get() + backoffMultiplierIncrement, maxBackoffMultiplier));
+    } else {
+      currentBackoffMultiplier
+        .set(Math.max(currentBackoffMultiplier.get() - backoffMultiplierDecrement, 1.0));
+    }
+
+    double avgUtil = utilizationEma;
+    if (avgUtil < minTargetUtilization) {
+      oversubscriptionProportion.set(Math
+        .min(oversubscriptionProportion.get() + oversubscriptionIncrement, maxOversubscription));
+    } else if (avgUtil >= maxTargetUtilization) {
+      oversubscriptionProportion
+        .set(Math.max(oversubscriptionProportion.get() - oversubscriptionDecrement, 0.0));
+    }
+
+    hadContentionThisInterval = false;
+    lastIntervalConsumed.set(0);
+
+    long refillAmount = refills * getRefillIntervalAdjustedLimit(limit);
+    long maxRefill = getOversubscribedLimit(limit);
+    return Math.min(maxRefill, refillAmount);
+  }
+
+  private long getOversubscribedLimit(long limit) {
+    return limit + (long) (limit * oversubscriptionProportion.get());
+  }
+
+  @Override
+  public void consume(long amount) {
+    super.consume(amount);
+    lastIntervalConsumed.addAndGet(amount);
+  }
+
+  @Override
+  public long getWaitInterval(long limit, long available, long amount) {
+    limit = getRefillIntervalAdjustedLimit(limit);
+    if (nextRefillTime == -1) return 0;
+
+    final long now = EnvironmentEdgeManager.currentTime();
+    final long refillTime = nextRefillTime;
+    long diff = amount - available;
+    if (diff > 0) hadContentionThisInterval = true;
+
+    long nextInterval = refillTime - now;
+    if (diff <= limit) {
+      return applyBackoffMultiplier(nextInterval);
+    }
+
+    long extra = diff / limit;
+    if (diff % limit == 0) extra--;
+    long baseWait = nextInterval + (extra * refillInterval);
+    return applyBackoffMultiplier(baseWait);
+  }
+
+  private long getRefillIntervalAdjustedLimit(long limit) {
+    return (long) Math.ceil(refillInterval / (double) getTimeUnitInMillis() * limit);
+  }
+
+  private long applyBackoffMultiplier(long baseWaitInterval) {
+    return (long) (baseWaitInterval * currentBackoffMultiplier.get());
+  }
+
+  // strictly for testing
+  @Override
+  public void setNextRefillTime(long nextRefillTime) {
+    this.nextRefillTime = nextRefillTime;
+  }
+
+  @Override
+  public long getNextRefillTime() {
+    return this.nextRefillTime;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
@@ -48,11 +48,10 @@ public class TimeBasedLimiter implements QuotaLimiter {
   private RateLimiter reqHandlerUsageTimeLimiter = null;
 
   private TimeBasedLimiter() {
-    if (
-      FixedIntervalRateLimiter.class.getName().equals(
-        conf.getClass(RateLimiter.QUOTA_RATE_LIMITER_CONF_KEY, AverageIntervalRateLimiter.class)
-          .getName())
-    ) {
+    String limiterClassName =
+      conf.getClass(RateLimiter.QUOTA_RATE_LIMITER_CONF_KEY, AverageIntervalRateLimiter.class)
+        .getName();
+    if (FixedIntervalRateLimiter.class.getName().equals(limiterClassName)) {
       long refillInterval = conf.getLong(FixedIntervalRateLimiter.RATE_LIMITER_REFILL_INTERVAL_MS,
         RateLimiter.DEFAULT_TIME_UNIT);
       reqsLimiter = new FixedIntervalRateLimiter(refillInterval);
@@ -68,6 +67,22 @@ public class TimeBasedLimiter implements QuotaLimiter {
       atomicReadSizeLimiter = new FixedIntervalRateLimiter(refillInterval);
       atomicWriteSizeLimiter = new FixedIntervalRateLimiter(refillInterval);
       reqHandlerUsageTimeLimiter = new FixedIntervalRateLimiter(refillInterval);
+    } else if (FeedbackAdaptiveRateLimiter.class.getName().equals(limiterClassName)) {
+      FeedbackAdaptiveRateLimiter.FeedbackAdaptiveRateLimiterFactory feedbackLimiterFactory =
+        new FeedbackAdaptiveRateLimiter.FeedbackAdaptiveRateLimiterFactory(conf);
+      reqsLimiter = feedbackLimiterFactory.create();
+      reqSizeLimiter = feedbackLimiterFactory.create();
+      writeReqsLimiter = feedbackLimiterFactory.create();
+      writeSizeLimiter = feedbackLimiterFactory.create();
+      readReqsLimiter = feedbackLimiterFactory.create();
+      readSizeLimiter = feedbackLimiterFactory.create();
+      reqCapacityUnitLimiter = feedbackLimiterFactory.create();
+      writeCapacityUnitLimiter = feedbackLimiterFactory.create();
+      readCapacityUnitLimiter = feedbackLimiterFactory.create();
+      atomicReqLimiter = feedbackLimiterFactory.create();
+      atomicReadSizeLimiter = feedbackLimiterFactory.create();
+      atomicWriteSizeLimiter = feedbackLimiterFactory.create();
+      reqHandlerUsageTimeLimiter = feedbackLimiterFactory.create();
     } else {
       reqsLimiter = new AverageIntervalRateLimiter();
       reqSizeLimiter = new AverageIntervalRateLimiter();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestFeedbackAdaptiveRateLimiter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestFeedbackAdaptiveRateLimiter.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.quotas;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.EnvironmentEdge;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Verify the behavior of the FeedbackAdaptiveRateLimiter including adaptive backoff multipliers and
+ * over-subscription functionality.
+ */
+@Category({ RegionServerTests.class, SmallTests.class })
+public class TestFeedbackAdaptiveRateLimiter {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestFeedbackAdaptiveRateLimiter.class);
+
+  private ManualEnvironmentEdge testEdge;
+  private FeedbackAdaptiveRateLimiter.FeedbackAdaptiveRateLimiterFactory factory;
+
+  @Before
+  public void setUp() {
+    testEdge = new ManualEnvironmentEdge();
+    EnvironmentEdgeManager.injectEdge(testEdge);
+
+    Configuration conf = HBaseConfiguration.create();
+    // Set refill interval for testing
+    conf.setLong(FixedIntervalRateLimiter.RATE_LIMITER_REFILL_INTERVAL_MS, 500);
+    // Configure adaptive parameters for testing - using larger values than defaults for
+    // observability
+    conf.setDouble(FeedbackAdaptiveRateLimiter.FEEDBACK_ADAPTIVE_BACKOFF_MULTIPLIER_INCREMENT, 0.1);
+    conf.setDouble(FeedbackAdaptiveRateLimiter.FEEDBACK_ADAPTIVE_BACKOFF_MULTIPLIER_DECREMENT,
+      0.05);
+    conf.setDouble(FeedbackAdaptiveRateLimiter.FEEDBACK_ADAPTIVE_MAX_BACKOFF_MULTIPLIER, 3.0);
+    conf.setDouble(FeedbackAdaptiveRateLimiter.FEEDBACK_ADAPTIVE_OVERSUBSCRIPTION_INCREMENT, 0.01);
+    conf.setDouble(FeedbackAdaptiveRateLimiter.FEEDBACK_ADAPTIVE_OVERSUBSCRIPTION_DECREMENT, 0.005);
+    conf.setDouble(FeedbackAdaptiveRateLimiter.FEEDBACK_ADAPTIVE_MAX_OVERSUBSCRIPTION, 0.2);
+    conf.setDouble(FeedbackAdaptiveRateLimiter.FEEDBACK_ADAPTIVE_UTILIZATION_ERROR_BUDGET, 0.1);
+
+    factory = new FeedbackAdaptiveRateLimiter.FeedbackAdaptiveRateLimiterFactory(conf);
+  }
+
+  @After
+  public void tearDown() {
+    EnvironmentEdgeManager.reset();
+  }
+
+  @Test
+  public void testBasicFunctionality() {
+    FeedbackAdaptiveRateLimiter limiter = factory.create();
+    limiter.set(10, TimeUnit.SECONDS);
+
+    // Initially should work like normal rate limiter
+    assertEquals(0, limiter.getWaitIntervalMs());
+    limiter.consume(5);
+    assertEquals(0, limiter.getWaitIntervalMs());
+    limiter.consume(5);
+
+    // Should need to wait after consuming full limit
+    assertTrue(limiter.getWaitIntervalMs() > 0);
+  }
+
+  @Test
+  public void testAdaptiveBackoffIncreases() {
+    FeedbackAdaptiveRateLimiter limiter = factory.create();
+    limiter.set(10, TimeUnit.SECONDS);
+
+    testEdge.setValue(1000);
+
+    // Test that adaptive backoff functionality works without throwing exceptions
+    // and that we can create contention scenarios
+    for (int i = 0; i < 3; i++) {
+      limiter.refill(10);
+      limiter.consume(10);
+      // Create contention by asking for more than available
+      long waitInterval = limiter.getWaitInterval(10, 0, 1);
+
+      // Basic sanity check - wait interval should be reasonable
+      assertTrue("Wait interval should be positive, got: " + waitInterval, waitInterval > 0);
+
+      // Advance to next interval
+      testEdge.setValue(1000 + (i + 1) * 500);
+    }
+
+    // Test passes if the adaptive backoff mechanism works without errors
+    assertTrue("Adaptive backoff should work without errors", true);
+  }
+
+  @Test
+  public void testAdaptiveBackoffDecreases() {
+    FeedbackAdaptiveRateLimiter limiter = factory.create();
+    limiter.set(10, TimeUnit.SECONDS);
+
+    testEdge.setValue(1000);
+
+    // Test that the backoff decrease mechanism works without errors
+    // Build up some contention first
+    for (int i = 0; i < 3; i++) {
+      limiter.refill(10);
+      limiter.consume(10);
+      limiter.getWaitInterval(10, 0, 1); // Create contention
+      testEdge.setValue(1000 + (i + 1) * 500);
+    }
+
+    // Run several intervals without contention to decrease backoff
+    for (int i = 0; i < 10; i++) {
+      testEdge.setValue(2500 + i * 500);
+      limiter.refill(10);
+      if (limiter.getAvailable() > 0) {
+        limiter.consume(Math.min(5, (int) limiter.getAvailable())); // Consume less than limit
+      }
+    }
+
+    // Test passes if the backoff decrease mechanism works without errors
+    assertTrue("Adaptive backoff decrease should work without errors", true);
+  }
+
+  @Test
+  public void testOversubscriptionTracking() {
+    FeedbackAdaptiveRateLimiter limiter = factory.create();
+    limiter.set(10, TimeUnit.SECONDS);
+
+    testEdge.setValue(1000);
+
+    // Initial refill to set up the limiter
+    long initialRefill = limiter.refill(10);
+    assertTrue("Initial refill should be positive", initialRefill > 0);
+
+    // Just verify that the over-subscription tracking is working without complex assertions
+    // This test mainly ensures that the adaptive behavior doesn't break basic functionality
+    for (int i = 0; i < 5; i++) {
+      testEdge.setValue(1000 + (i + 1) * 500); // Use 500ms intervals, start from next interval
+      long refilled = limiter.refill(10);
+
+      if (refilled > 0) {
+        // Only test when we actually get resources
+        limiter.consume(Math.min(8, (int) refilled));
+        long waitInterval = limiter.getWaitInterval(10, 2, 5);
+        assertTrue("Wait interval should be reasonable", waitInterval >= 0);
+      }
+    }
+
+    // Test passes if no exceptions are thrown
+    assertTrue("Over-subscription tracking should work without errors", true);
+  }
+
+  @Test
+  public void testUtilizationTracking() {
+    FeedbackAdaptiveRateLimiter limiter = factory.create();
+    limiter.set(10, TimeUnit.SECONDS);
+
+    testEdge.setValue(1000);
+
+    // Test various utilization levels to ensure tracking works
+    for (int i = 0; i < 5; i++) {
+      testEdge.setValue(1000 + i * 500); // Use 500ms intervals
+      limiter.refill(10);
+
+      // Vary consumption from 20% to 100%
+      int consumption = 2 + (i * 2);
+      limiter.consume(consumption);
+    }
+
+    // The limiter should have tracked utilization without throwing exceptions
+    assertTrue("Utilization tracking should work correctly", true);
+  }
+
+  @Test
+  public void testConcurrentAccess() throws InterruptedException {
+    FeedbackAdaptiveRateLimiter limiter = factory.create();
+    limiter.set(100, TimeUnit.SECONDS);
+
+    testEdge.setValue(1000);
+    limiter.refill(100);
+
+    // Simulate concurrent access
+    Thread[] threads = new Thread[10];
+    for (int i = 0; i < threads.length; i++) {
+      threads[i] = new Thread(() -> {
+        for (int j = 0; j < 10; j++) {
+          limiter.consume(1);
+          limiter.getWaitInterval(100, 50, 1);
+        }
+      });
+    }
+
+    for (Thread thread : threads) {
+      thread.start();
+    }
+
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    // Should complete without exceptions - basic thread safety verification
+    assertTrue("Concurrent access should complete successfully", true);
+  }
+
+  @Test
+  public void testOverconsumptionBehavior() {
+    FeedbackAdaptiveRateLimiter limiter = factory.create();
+    limiter.set(10, TimeUnit.SECONDS);
+
+    testEdge.setValue(1000);
+    limiter.refill(10);
+
+    // Over-consume significantly
+    limiter.consume(20);
+
+    // Should require waiting for multiple intervals (500ms refill interval)
+    long waitInterval = limiter.getWaitInterval(10, -10, 1);
+    assertTrue("Should require substantial wait after over-consumption", waitInterval >= 500);
+  }
+
+  private static class ManualEnvironmentEdge implements EnvironmentEdge {
+    private long currentTime = 1000;
+
+    public void setValue(long time) {
+      this.currentTime = time;
+    }
+
+    @Override
+    public long currentTime() {
+      return currentTime;
+    }
+  }
+}


### PR DESCRIPTION
…t merged upstream)

The initial setup for this new rate limiter is super hand wavy, and it will ideally need to work well enough at its default configurations for a wide variety of use-cases. So I'd love to get more solid usage data at hubspot before we commit anything upstream