### PR TITLE
HubSpot Backport: Rack aware incremental backup (not yet proposed upstream)

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
@@ -35,6 +35,8 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_SET;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_SET_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME;
@@ -159,6 +161,7 @@ public class BackupDriver extends AbstractHBaseTool {
     addOptWithArg(OPTION_PATH, OPTION_PATH_DESC);
     addOptWithArg(OPTION_KEEP, OPTION_KEEP_DESC);
     addOptWithArg(OPTION_YARN_QUEUE_NAME, OPTION_YARN_QUEUE_NAME_DESC);
+    addOptWithArg(OPTION_WAL_LOCATION_RESOLVER, OPTION_WAL_LOCATION_RESOLVER_DESC);
 
   }
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
@@ -37,6 +37,10 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_CUSTOM_GROUPER;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_CUSTOM_GROUPER_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME;
@@ -162,6 +166,8 @@ public class BackupDriver extends AbstractHBaseTool {
     addOptWithArg(OPTION_KEEP, OPTION_KEEP_DESC);
     addOptWithArg(OPTION_YARN_QUEUE_NAME, OPTION_YARN_QUEUE_NAME_DESC);
     addOptWithArg(OPTION_WAL_LOCATION_RESOLVER, OPTION_WAL_LOCATION_RESOLVER_DESC);
+    addOptWithArg(OPTION_HFILE_CUSTOM_GROUPER, OPTION_HFILE_CUSTOM_GROUPER_DESC);
+    addOptWithArg(OPTION_HFILE_LOCATION_RESOLVER, OPTION_HFILE_LOCATION_RESOLVER_DESC);
 
   }
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
@@ -37,8 +37,6 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER_DESC;
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_CUSTOM_GROUPER;
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_CUSTOM_GROUPER_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS;
@@ -166,7 +164,6 @@ public class BackupDriver extends AbstractHBaseTool {
     addOptWithArg(OPTION_KEEP, OPTION_KEEP_DESC);
     addOptWithArg(OPTION_YARN_QUEUE_NAME, OPTION_YARN_QUEUE_NAME_DESC);
     addOptWithArg(OPTION_WAL_LOCATION_RESOLVER, OPTION_WAL_LOCATION_RESOLVER_DESC);
-    addOptWithArg(OPTION_HFILE_CUSTOM_GROUPER, OPTION_HFILE_CUSTOM_GROUPER_DESC);
     addOptWithArg(OPTION_HFILE_LOCATION_RESOLVER, OPTION_HFILE_LOCATION_RESOLVER_DESC);
 
   }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
@@ -22,6 +22,8 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BANDW
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BANDWIDTH_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_IGNORECHECKSUM;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_IGNORECHECKSUM_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_KEEP;
@@ -37,8 +39,6 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER_DESC;
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER;
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME;

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
@@ -100,6 +100,14 @@ public interface BackupRestoreConstants {
   String OPTION_WAL_LOCATION_RESOLVER_DESC =
     "WAL file location resolver class for rack-aware incremental backup";
 
+  String OPTION_HFILE_CUSTOM_GROUPER = "hfile-custom-grouper";
+  String OPTION_HFILE_CUSTOM_GROUPER_DESC =
+    "HFile custom grouper class for rack-aware bulk loading during incremental backup";
+
+  String OPTION_HFILE_LOCATION_RESOLVER = "hfile-location-resolver";
+  String OPTION_HFILE_LOCATION_RESOLVER_DESC =
+    "HFile location resolver class for rack-aware bulk loading during incremental backup";
+
   String JOB_NAME_CONF_KEY = "mapreduce.job.name";
 
   String BACKUP_CONFIG_STRING =

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
@@ -96,6 +96,10 @@ public interface BackupRestoreConstants {
   String OPTION_YARN_QUEUE_NAME_DESC = "Yarn queue name to run backup create command on";
   String OPTION_YARN_QUEUE_NAME_RESTORE_DESC = "Yarn queue name to run backup restore command on";
 
+  String OPTION_WAL_LOCATION_RESOLVER = "wal-location-resolver";
+  String OPTION_WAL_LOCATION_RESOLVER_DESC =
+    "WAL file location resolver class for rack-aware incremental backup";
+
   String JOB_NAME_CONF_KEY = "mapreduce.job.name";
 
   String BACKUP_CONFIG_STRING =

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
@@ -100,10 +100,6 @@ public interface BackupRestoreConstants {
   String OPTION_WAL_LOCATION_RESOLVER_DESC =
     "WAL file location resolver class for rack-aware incremental backup";
 
-  String OPTION_HFILE_CUSTOM_GROUPER = "hfile-custom-grouper";
-  String OPTION_HFILE_CUSTOM_GROUPER_DESC =
-    "HFile custom grouper class for rack-aware bulk loading during incremental backup";
-
   String OPTION_HFILE_LOCATION_RESOLVER = "hfile-location-resolver";
   String OPTION_HFILE_LOCATION_RESOLVER_DESC =
     "HFile location resolver class for rack-aware bulk loading during incremental backup";

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -37,11 +37,11 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_SET_D
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_LIST_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WAL_LOCATION_RESOLVER;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME_DESC;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -66,7 +66,6 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.yetus.audience.InterfaceAudience;
-
 import org.apache.hbase.thirdparty.com.google.common.base.Splitter;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
@@ -82,6 +81,9 @@ public final class BackupCommands {
 
   public final static String TOP_LEVEL_NOT_ALLOWED =
     "Top level (root) folder is not allowed to be a backup destination";
+
+  // Configuration key for WAL location resolver (must match WALPlayer.CONF_WAL_FILE_LOCATION_RESOLVER_CLASS)
+  private static final String CONF_WAL_FILE_LOCATION_RESOLVER_CLASS = "wal.backup.file.location.resolver.class";
 
   public static final String USAGE = "Usage: hbase backup COMMAND [command-specific arguments]\n"
     + "where COMMAND is one of:\n" + "  create     create a new backup image\n"
@@ -146,6 +148,12 @@ public final class BackupCommands {
         String queueName = cmdline.getOptionValue(OPTION_YARN_QUEUE_NAME);
         // Set MR job queuename to configuration
         getConf().set("mapreduce.job.queuename", queueName);
+      }
+
+
+      if (cmdline.hasOption(OPTION_WAL_LOCATION_RESOLVER)) {
+        String resolverClass = cmdline.getOptionValue(OPTION_WAL_LOCATION_RESOLVER);
+        getConf().set(CONF_WAL_FILE_LOCATION_RESOLVER_CLASS, resolverClass);
       }
 
       // Create connection

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -22,6 +22,8 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BANDW
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BANDWIDTH_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_CUSTOM_GROUPER;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_IGNORECHECKSUM;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_IGNORECHECKSUM_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_KEEP;
@@ -84,6 +86,10 @@ public final class BackupCommands {
 
   // Configuration key for WAL location resolver (must match WALPlayer.CONF_WAL_FILE_LOCATION_RESOLVER_CLASS)
   private static final String CONF_WAL_FILE_LOCATION_RESOLVER_CLASS = "wal.backup.file.location.resolver.class";
+  
+  // Configuration keys for HFile rack-aware processing (must match MapReduceHFileSplitterJob)
+  private static final String CONF_HFILE_CUSTOM_GROUPER_CLASS = "hfile.backup.input.file.grouper.class";
+  private static final String CONF_HFILE_LOCATION_RESOLVER_CLASS = "hfile.backup.input.file.location.resolver.class";
 
   public static final String USAGE = "Usage: hbase backup COMMAND [command-specific arguments]\n"
     + "where COMMAND is one of:\n" + "  create     create a new backup image\n"
@@ -154,6 +160,16 @@ public final class BackupCommands {
       if (cmdline.hasOption(OPTION_WAL_LOCATION_RESOLVER)) {
         String resolverClass = cmdline.getOptionValue(OPTION_WAL_LOCATION_RESOLVER);
         getConf().set(CONF_WAL_FILE_LOCATION_RESOLVER_CLASS, resolverClass);
+      }
+
+      if (cmdline.hasOption(OPTION_HFILE_CUSTOM_GROUPER)) {
+        String grouperClass = cmdline.getOptionValue(OPTION_HFILE_CUSTOM_GROUPER);
+        getConf().set(CONF_HFILE_CUSTOM_GROUPER_CLASS, grouperClass);
+      }
+
+      if (cmdline.hasOption(OPTION_HFILE_LOCATION_RESOLVER)) {
+        String resolverClass = cmdline.getOptionValue(OPTION_HFILE_LOCATION_RESOLVER);
+        getConf().set(CONF_HFILE_LOCATION_RESOLVER_CLASS, resolverClass);
       }
 
       // Create connection

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BANDW
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BANDWIDTH_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG_DESC;
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_CUSTOM_GROUPER;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_HFILE_LOCATION_RESOLVER;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_IGNORECHECKSUM;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_IGNORECHECKSUM_DESC;
@@ -87,8 +86,7 @@ public final class BackupCommands {
   // Configuration key for WAL location resolver (must match WALPlayer.CONF_WAL_FILE_LOCATION_RESOLVER_CLASS)
   private static final String CONF_WAL_FILE_LOCATION_RESOLVER_CLASS = "wal.backup.file.location.resolver.class";
   
-  // Configuration keys for HFile rack-aware processing (must match MapReduceHFileSplitterJob)
-  private static final String CONF_HFILE_CUSTOM_GROUPER_CLASS = "hfile.backup.input.file.grouper.class";
+  // Configuration key for HFile rack-aware processing (must match MapReduceHFileSplitterJob)
   private static final String CONF_HFILE_LOCATION_RESOLVER_CLASS = "hfile.backup.input.file.location.resolver.class";
 
   public static final String USAGE = "Usage: hbase backup COMMAND [command-specific arguments]\n"
@@ -160,11 +158,6 @@ public final class BackupCommands {
       if (cmdline.hasOption(OPTION_WAL_LOCATION_RESOLVER)) {
         String resolverClass = cmdline.getOptionValue(OPTION_WAL_LOCATION_RESOLVER);
         getConf().set(CONF_WAL_FILE_LOCATION_RESOLVER_CLASS, resolverClass);
-      }
-
-      if (cmdline.hasOption(OPTION_HFILE_CUSTOM_GROUPER)) {
-        String grouperClass = cmdline.getOptionValue(OPTION_HFILE_CUSTOM_GROUPER);
-        getConf().set(CONF_HFILE_CUSTOM_GROUPER_CLASS, grouperClass);
       }
 
       if (cmdline.hasOption(OPTION_HFILE_LOCATION_RESOLVER)) {

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -43,6 +43,7 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKE
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME_DESC;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -67,6 +68,7 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.yetus.audience.InterfaceAudience;
+
 import org.apache.hbase.thirdparty.com.google.common.base.Splitter;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
@@ -83,11 +85,13 @@ public final class BackupCommands {
   public final static String TOP_LEVEL_NOT_ALLOWED =
     "Top level (root) folder is not allowed to be a backup destination";
 
-  // Configuration key for WAL location resolver (must match WALPlayer.CONF_WAL_FILE_LOCATION_RESOLVER_CLASS)
-  private static final String CONF_WAL_FILE_LOCATION_RESOLVER_CLASS = "wal.backup.file.location.resolver.class";
-  
-  // Configuration key for HFile rack-aware processing (must match MapReduceHFileSplitterJob)
-  private static final String CONF_HFILE_LOCATION_RESOLVER_CLASS = "hfile.backup.input.file.location.resolver.class";
+  // Configuration keys for location resolvers
+  // Must match WALPlayer.CONF_WAL_FILE_LOCATION_RESOLVER_CLASS
+  private static final String CONF_WAL_FILE_LOCATION_RESOLVER_CLASS =
+    "wal.backup.file.location.resolver.class";
+  // Must match HFileInputFormat.CONF_HFILE_LOCATION_RESOLVER_CLASS
+  private static final String CONF_HFILE_LOCATION_RESOLVER_CLASS =
+    "hfile.backup.input.file.location.resolver.class";
 
   public static final String USAGE = "Usage: hbase backup COMMAND [command-specific arguments]\n"
     + "where COMMAND is one of:\n" + "  create     create a new backup image\n"
@@ -153,7 +157,6 @@ public final class BackupCommands {
         // Set MR job queuename to configuration
         getConf().set("mapreduce.job.queuename", queueName);
       }
-
 
       if (cmdline.hasOption(OPTION_WAL_LOCATION_RESOLVER)) {
         String resolverClass = cmdline.getOptionValue(OPTION_WAL_LOCATION_RESOLVER);

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
@@ -70,9 +70,6 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 public class IncrementalTableBackupClient extends TableBackupClient {
   private static final Logger LOG = LoggerFactory.getLogger(IncrementalTableBackupClient.class);
-  
-  // Configuration key for WAL location resolver (must match WALPlayer.CONF_WAL_FILE_LOCATION_RESOLVER_CLASS)
-  private static final String CONF_WAL_FILE_LOCATION_RESOLVER_CLASS = "wal.backup.file.location.resolver.class";
 
   protected IncrementalTableBackupClient() {
   }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
@@ -51,7 +50,6 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.mapreduce.HFileOutputFormat2;
 import org.apache.hadoop.hbase.mapreduce.WALPlayer;
-import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos;
 import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.SnapshotManifest;
 import org.apache.hadoop.hbase.snapshot.SnapshotRegionLocator;
@@ -59,10 +57,13 @@ import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.HFileArchiveUtil;
 import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
 import org.apache.hadoop.util.Tool;
-import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos;
 
 /**
  * Incremental backup implementation. See the {@link #execute() execute} method.
@@ -411,7 +412,8 @@ public class IncrementalTableBackupClient extends TableBackupClient {
     conf.setBoolean(WALPlayer.MULTI_TABLES_SUPPORT, true);
     conf.set(JOB_NAME_CONF_KEY, jobname);
 
-    // Rack-aware WAL processing configuration is set directly via command line to the same key WALPlayer uses
+    // Rack-aware WAL processing configuration is set directly via command line to the same key
+    // WALPlayer uses
     String[] playerArgs = { dirs, StringUtils.join(tableList, ",") };
 
     try {

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceHFileSplitterJob.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceHFileSplitterJob.java
@@ -18,8 +18,14 @@
 package org.apache.hadoop.hbase.backup.mapreduce;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -37,11 +43,16 @@ import org.apache.hadoop.hbase.mapreduce.TableMapReduceUtil;
 import org.apache.hadoop.hbase.snapshot.SnapshotRegionLocator;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.MapReduceExtendedCell;
+import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -60,6 +71,10 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
   public final static String TABLES_KEY = "hfile.input.tables";
   public final static String TABLE_MAP_KEY = "hfile.input.tablesmap";
   private final static String JOB_NAME_CONF_KEY = "mapreduce.job.name";
+  
+  // Configuration keys for pluggable rack-aware processing (must match BackupCommands)
+  public final static String CONF_INPUT_FILE_GROUPER_CLASS = "hfile.backup.input.file.grouper.class";
+  public final static String CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS = "hfile.backup.input.file.location.resolver.class";
 
   public MapReduceHFileSplitterJob() {
   }
@@ -87,6 +102,152 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
   }
 
   /**
+   * Interface for custom file grouping logic to influence InputSplit creation for HFile processing.
+   * Similar to ExportSnapshot's CustomFileGrouper but for HFiles.
+   */
+  @InterfaceAudience.Public
+  public interface HFileCustomFileGrouper {
+    /**
+     * Groups HFiles into collections that should be processed together.
+     * Files in different groups are guaranteed not to be in the same InputSplit.
+     * 
+     * @param hfiles Collection of HFile paths and their sizes
+     * @return Collections of HFiles grouped by custom logic (e.g., rack, host, size)
+     */
+    Collection<Collection<Pair<String, Long>>> getGroupedInputFiles(
+      final Collection<Pair<String, Long>> hfiles);
+  }
+
+  /**
+   * Interface for resolving file locations to influence InputSplit placement for HFile processing.
+   * Similar to ExportSnapshot's FileLocationResolver but for HFiles.
+   */
+  @InterfaceAudience.Public
+  public interface HFileLocationResolver {
+    /**
+     * Get preferred locations for a group of HFiles to optimize rack-aware processing.
+     * 
+     * @param hfiles Collection of HFile paths and sizes that will be processed together
+     * @return Set of preferred host names for processing these HFiles
+     */
+    Set<String> getLocationsForInputFiles(final Collection<Pair<String, Long>> hfiles);
+  }
+
+  /**
+   * Default no-op implementation of HFileCustomFileGrouper.
+   * Provides backward compatibility by putting all files in a single group.
+   */
+  public static class NoopHFileCustomFileGrouper implements HFileCustomFileGrouper {
+    @Override
+    public Collection<Collection<Pair<String, Long>>> getGroupedInputFiles(
+        Collection<Pair<String, Long>> hfiles) {
+      // Single group containing all files - maintains original behavior
+      return Collections.singletonList(new ArrayList<>(hfiles));
+    }
+  }
+
+  /**
+   * Default no-op implementation of HFileLocationResolver.
+   * Provides backward compatibility by returning no location hints.
+   */
+  public static class NoopHFileLocationResolver implements HFileLocationResolver {
+    @Override
+    public Set<String> getLocationsForInputFiles(Collection<Pair<String, Long>> hfiles) {
+      // No location hints - lets YARN scheduler decide
+      return Collections.emptySet();
+    }
+  }
+
+  /**
+   * Rack-aware HFile input format that uses pluggable CustomFileGrouper and FileLocationResolver
+   * classes for optimal data locality. Follows the same pattern as ExportSnapshot.
+   */
+  @InterfaceAudience.Private
+  public static class RackAwareHFileInputFormat extends HFileInputFormat {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(RackAwareHFileInputFormat.class);
+    
+    @Override
+    public List<InputSplit> getSplits(JobContext context) throws IOException {
+      try {
+        return createRackAwareSplits(context);
+      } catch (Exception e) {
+        LOG.error("Error creating rack-aware splits, falling back to standard splits", e);
+        return super.getSplits(context);
+      }
+    }
+    
+    private List<InputSplit> createRackAwareSplits(JobContext context) 
+        throws IOException {
+      Configuration conf = context.getConfiguration();
+      
+      // 1. Get all HFiles from input paths
+      List<FileStatus> files = listStatus(context);
+      Collection<Pair<String, Long>> hfiles = new ArrayList<>();
+      for (FileStatus file : files) {
+        hfiles.add(new Pair<>(file.getPath().toString(), file.getLen()));
+      }
+      
+      // 2. Load pluggable CustomFileGrouper
+      Class<? extends HFileCustomFileGrouper> grouperClass = conf.getClass(
+        CONF_INPUT_FILE_GROUPER_CLASS, 
+        NoopHFileCustomFileGrouper.class, 
+        HFileCustomFileGrouper.class);
+      HFileCustomFileGrouper customFileGrouper = 
+        ReflectionUtils.newInstance(grouperClass, conf);
+      
+      // 3. Load pluggable FileLocationResolver
+      Class<? extends HFileLocationResolver> resolverClass = conf.getClass(
+        CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS,
+        NoopHFileLocationResolver.class,
+        HFileLocationResolver.class);
+      HFileLocationResolver fileLocationResolver = 
+        ReflectionUtils.newInstance(resolverClass, conf);
+      
+      // 4. Group files using custom grouper
+      Collection<Collection<Pair<String, Long>>> groupedFiles = 
+        customFileGrouper.getGroupedInputFiles(hfiles);
+      
+      // 5. Create InputSplits from grouped files
+      List<InputSplit> splits = new ArrayList<>();
+      
+      for (Collection<Pair<String, Long>> group : groupedFiles) {
+        // Get location hints for this group
+        Set<String> locations = fileLocationResolver.getLocationsForInputFiles(group);
+        String[] locationArray = locations.toArray(new String[0]);
+        
+        // Create balanced splits from this group
+        List<InputSplit> groupSplits = createBalancedSplits(group, locationArray);
+        splits.addAll(groupSplits);
+      }
+
+      LOG.info("Created {} rack-aware InputSplits from {} HFiles in {} groups", 
+        splits.size(), hfiles.size(), groupedFiles.size());
+      
+      return splits;
+    }
+    
+    private List<InputSplit> createBalancedSplits(Collection<Pair<String, Long>> hfiles, 
+        String[] locations) throws IOException {
+      List<InputSplit> splits = new ArrayList<>();
+      
+      // For now, create one split per HFile (can be enhanced for better balancing)
+      for (Pair<String, Long> hfile : hfiles) {
+        Path path = new Path(hfile.getFirst());
+        long length = hfile.getSecond();
+        if (length <= 0){
+          LOG.warn("Skipping empty or invalid Hfile: {} with length: {}", path, length);
+          continue;
+        }
+
+        splits.add(new FileSplit(path, 0, length, locations));
+      }
+      
+      return splits;
+    }
+  }
+
+  /**
    * Sets up the actual job.
    * @param args The command line parameters.
    * @return The newly created job.
@@ -105,7 +266,16 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
     job.getConfiguration().setBoolean(HFileOutputFormat2.EXTENDED_CELL_SERIALIZATION_ENABLED_KEY,
       true);
     job.setJarByClass(MapReduceHFileSplitterJob.class);
-    job.setInputFormatClass(HFileInputFormat.class);
+    
+    // BACKWARD COMPATIBLE: Choose InputFormat based on configuration
+    if (isRackAwarenessConfigured(conf)) {
+      LOG.info("Using RackAwareHFileInputFormat with pluggable classes");
+      job.setInputFormatClass(RackAwareHFileInputFormat.class);
+    } else {
+      LOG.info("Using standard HFileInputFormat");
+      job.setInputFormatClass(HFileInputFormat.class);
+    }
+    
     job.setMapOutputKeyClass(ImmutableBytesWritable.class);
     String hfileOutPath = conf.get(BULK_OUTPUT_CONF_KEY);
     if (hfileOutPath != null) {
@@ -132,6 +302,15 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
   }
 
   /**
+   * Check if rack awareness is configured
+   * Both grouper and location resolver should be configured for effective rack awareness
+   */
+  private boolean isRackAwarenessConfigured(Configuration conf) {
+    return conf.get(CONF_INPUT_FILE_GROUPER_CLASS) != null &&
+           conf.get(CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS) != null;
+  }
+
+  /**
    * Print usage
    * @param errorMsg Error message. Can be null.
    */
@@ -147,6 +326,15 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
     System.err.println("Other options:");
     System.err.println("   -D " + JOB_NAME_CONF_KEY
       + "=jobName - use the specified mapreduce job name for the HFile splitter");
+    
+    // NEW: Pluggable class options
+    System.err.println("Rack-aware processing options (both required for full rack awareness):");
+    System.err.println("  -D" + CONF_INPUT_FILE_GROUPER_CLASS + "=<class> - " + 
+      "HFile custom grouper class for rack-aware processing");
+    System.err.println("  -D" + CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS + "=<class> - " + 
+      "HFile location resolver class for rack-aware processing");
+    System.err.println("  Note: Both grouper and location resolver must be configured together");
+    
     System.err.println("For performance also consider the following options:\n"
       + "  -Dmapreduce.map.speculative=false\n" + "  -Dmapreduce.reduce.speculative=false");
   }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceHFileSplitterJob.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceHFileSplitterJob.java
@@ -72,8 +72,7 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
   public final static String TABLE_MAP_KEY = "hfile.input.tablesmap";
   private final static String JOB_NAME_CONF_KEY = "mapreduce.job.name";
   
-  // Configuration keys for pluggable rack-aware processing (must match BackupCommands)
-  public final static String CONF_INPUT_FILE_GROUPER_CLASS = "hfile.backup.input.file.grouper.class";
+  // Configuration key for pluggable rack-aware processing (must match BackupCommands)
   public final static String CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS = "hfile.backup.input.file.location.resolver.class";
 
   public MapReduceHFileSplitterJob() {
@@ -101,22 +100,6 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
     }
   }
 
-  /**
-   * Interface for custom file grouping logic to influence InputSplit creation for HFile processing.
-   * Similar to ExportSnapshot's CustomFileGrouper but for HFiles.
-   */
-  @InterfaceAudience.Public
-  public interface HFileCustomFileGrouper {
-    /**
-     * Groups HFiles into collections that should be processed together.
-     * Files in different groups are guaranteed not to be in the same InputSplit.
-     * 
-     * @param hfiles Collection of HFile paths and their sizes
-     * @return Collections of HFiles grouped by custom logic (e.g., rack, host, size)
-     */
-    Collection<Collection<Pair<String, Long>>> getGroupedInputFiles(
-      final Collection<Pair<String, Long>> hfiles);
-  }
 
   /**
    * Interface for resolving file locations to influence InputSplit placement for HFile processing.
@@ -133,18 +116,6 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
     Set<String> getLocationsForInputFiles(final Collection<Pair<String, Long>> hfiles);
   }
 
-  /**
-   * Default no-op implementation of HFileCustomFileGrouper.
-   * Provides backward compatibility by putting all files in a single group.
-   */
-  public static class NoopHFileCustomFileGrouper implements HFileCustomFileGrouper {
-    @Override
-    public Collection<Collection<Pair<String, Long>>> getGroupedInputFiles(
-        Collection<Pair<String, Long>> hfiles) {
-      // Single group containing all files - maintains original behavior
-      return Collections.singletonList(new ArrayList<>(hfiles));
-    }
-  }
 
   /**
    * Default no-op implementation of HFileLocationResolver.
@@ -159,8 +130,8 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
   }
 
   /**
-   * Rack-aware HFile input format that uses pluggable CustomFileGrouper and FileLocationResolver
-   * classes for optimal data locality. Follows the same pattern as ExportSnapshot.
+   * Rack-aware HFile input format that uses pluggable FileLocationResolver
+   * class for optimal data locality.
    */
   @InterfaceAudience.Private
   public static class RackAwareHFileInputFormat extends HFileInputFormat {
@@ -188,15 +159,7 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
         hfiles.add(new Pair<>(file.getPath().toString(), file.getLen()));
       }
       
-      // 2. Load pluggable CustomFileGrouper
-      Class<? extends HFileCustomFileGrouper> grouperClass = conf.getClass(
-        CONF_INPUT_FILE_GROUPER_CLASS, 
-        NoopHFileCustomFileGrouper.class, 
-        HFileCustomFileGrouper.class);
-      HFileCustomFileGrouper customFileGrouper = 
-        ReflectionUtils.newInstance(grouperClass, conf);
-      
-      // 3. Load pluggable FileLocationResolver
+      // 2. Load pluggable FileLocationResolver
       Class<? extends HFileLocationResolver> resolverClass = conf.getClass(
         CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS,
         NoopHFileLocationResolver.class,
@@ -204,47 +167,32 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
       HFileLocationResolver fileLocationResolver = 
         ReflectionUtils.newInstance(resolverClass, conf);
       
-      // 4. Group files using custom grouper
-      Collection<Collection<Pair<String, Long>>> groupedFiles = 
-        customFileGrouper.getGroupedInputFiles(hfiles);
-      
-      // 5. Create InputSplits from grouped files
+      // 3. Create InputSplits directly - one per file
       List<InputSplit> splits = new ArrayList<>();
       
-      for (Collection<Pair<String, Long>> group : groupedFiles) {
-        // Get location hints for this group
-        Set<String> locations = fileLocationResolver.getLocationsForInputFiles(group);
+      for (Pair<String, Long> hfile : hfiles) {
+        Path path = new Path(hfile.getFirst());
+        long length = hfile.getSecond();
+        
+        if (length <= 0) {
+          LOG.warn("Skipping empty or invalid HFile: {} with length: {}", path, length);
+          continue;
+        }
+        
+        // Get location hints for this individual file
+        Set<String> locations = fileLocationResolver.getLocationsForInputFiles(
+          Collections.singletonList(hfile));
         String[] locationArray = locations.toArray(new String[0]);
         
-        // Create balanced splits from this group
-        List<InputSplit> groupSplits = createBalancedSplits(group, locationArray);
-        splits.addAll(groupSplits);
+        splits.add(new FileSplit(path, 0, length, locationArray));
       }
-
-      LOG.info("Created {} rack-aware InputSplits from {} HFiles in {} groups", 
-        splits.size(), hfiles.size(), groupedFiles.size());
+      
+      LOG.info("Created {} rack-aware InputSplits from {} HFiles", 
+        splits.size(), hfiles.size());
       
       return splits;
     }
     
-    private List<InputSplit> createBalancedSplits(Collection<Pair<String, Long>> hfiles, 
-        String[] locations) throws IOException {
-      List<InputSplit> splits = new ArrayList<>();
-      
-      // For now, create one split per HFile (can be enhanced for better balancing)
-      for (Pair<String, Long> hfile : hfiles) {
-        Path path = new Path(hfile.getFirst());
-        long length = hfile.getSecond();
-        if (length <= 0){
-          LOG.warn("Skipping empty or invalid Hfile: {} with length: {}", path, length);
-          continue;
-        }
-
-        splits.add(new FileSplit(path, 0, length, locations));
-      }
-      
-      return splits;
-    }
   }
 
   /**
@@ -303,11 +251,10 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
 
   /**
    * Check if rack awareness is configured
-   * Both grouper and location resolver should be configured for effective rack awareness
+   * Location resolver should be configured for effective rack awareness
    */
   private boolean isRackAwarenessConfigured(Configuration conf) {
-    return conf.get(CONF_INPUT_FILE_GROUPER_CLASS) != null &&
-           conf.get(CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS) != null;
+    return conf.get(CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS) != null;
   }
 
   /**
@@ -328,12 +275,9 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
       + "=jobName - use the specified mapreduce job name for the HFile splitter");
     
     // NEW: Pluggable class options
-    System.err.println("Rack-aware processing options (both required for full rack awareness):");
-    System.err.println("  -D" + CONF_INPUT_FILE_GROUPER_CLASS + "=<class> - " + 
-      "HFile custom grouper class for rack-aware processing");
+    System.err.println("Rack-aware processing option:");
     System.err.println("  -D" + CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS + "=<class> - " + 
       "HFile location resolver class for rack-aware processing");
-    System.err.println("  Note: Both grouper and location resolver must be configured together");
     
     System.err.println("For performance also consider the following options:\n"
       + "  -Dmapreduce.map.speculative=false\n" + "  -Dmapreduce.reduce.speculative=false");

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceHFileSplitterJob.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceHFileSplitterJob.java
@@ -18,14 +18,8 @@
 package org.apache.hadoop.hbase.backup.mapreduce;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -44,14 +38,10 @@ import org.apache.hadoop.hbase.snapshot.SnapshotRegionLocator;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.MapReduceExtendedCell;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
-import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
-import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -70,9 +60,6 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
   public final static String TABLES_KEY = "hfile.input.tables";
   public final static String TABLE_MAP_KEY = "hfile.input.tablesmap";
   private final static String JOB_NAME_CONF_KEY = "mapreduce.job.name";
-  
-  // Configuration key for pluggable rack-aware processing (must match BackupCommands)
-  public final static String CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS = "hfile.backup.input.file.location.resolver.class";
 
   public MapReduceHFileSplitterJob() {
   }
@@ -99,101 +86,6 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
     }
   }
 
-
-  /**
-   * Interface for resolving file locations to influence InputSplit placement for HFile processing.
-   * Similar to ExportSnapshot's FileLocationResolver but for HFiles.
-   */
-  @InterfaceAudience.Public
-  public interface HFileLocationResolver {
-    /**
-     * Get preferred locations for a group of HFiles to optimize rack-aware processing.
-     * 
-     * @param hfiles Collection of HFile paths that will be processed together
-     * @return Set of preferred host names for processing these HFiles
-     */
-    Set<String> getLocationsForInputFiles(final Collection<String> hfiles);
-  }
-
-
-  /**
-   * Default no-op implementation of HFileLocationResolver.
-   * Provides backward compatibility by returning no location hints.
-   */
-  public static class NoopHFileLocationResolver implements HFileLocationResolver {
-    @Override
-    public Set<String> getLocationsForInputFiles(Collection<String> hfiles) {
-      // No location hints - lets YARN scheduler decide
-      return Collections.emptySet();
-    }
-  }
-
-  /**
-   * Rack-aware HFile input format that uses pluggable FileLocationResolver
-   * class for optimal data locality.
-   */
-  @InterfaceAudience.Private
-  public static class RackAwareHFileInputFormat extends HFileInputFormat {
-    
-    private static final Logger LOG = LoggerFactory.getLogger(RackAwareHFileInputFormat.class);
-    
-    @Override
-    public List<InputSplit> getSplits(JobContext context) throws IOException {
-      try {
-        return createRackAwareSplits(context);
-      } catch (Exception e) {
-        LOG.error("Error creating rack-aware splits, falling back to standard splits", e);
-        return super.getSplits(context);
-      }
-    }
-    
-    private List<InputSplit> createRackAwareSplits(JobContext context) 
-        throws IOException {
-      Configuration conf = context.getConfiguration();
-      
-      // 1. Get all HFiles from input paths
-      List<FileStatus> files = listStatus(context);
-      Collection<String> hfilePaths = new ArrayList<>();
-      for (FileStatus file : files) {
-        hfilePaths.add(file.getPath().toString());
-      }
-      
-      // 2. Load pluggable FileLocationResolver
-      Class<? extends HFileLocationResolver> resolverClass = conf.getClass(
-        CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS,
-        NoopHFileLocationResolver.class,
-        HFileLocationResolver.class);
-      HFileLocationResolver fileLocationResolver = 
-        ReflectionUtils.newInstance(resolverClass, conf);
-      
-      // 3. Create InputSplits directly - one per file
-      List<InputSplit> splits = new ArrayList<>();
-      
-      for (FileStatus file : files) {
-        Path path = file.getPath();
-        long length = file.getLen();
-        
-        if (length <= 0) {
-          LOG.warn("Skipping empty or invalid HFile: {} with length: {}", path, length);
-          continue;
-        }
-        
-        // Get location hints for this individual file
-        Set<String> locations = fileLocationResolver.getLocationsForInputFiles(
-          Collections.singletonList(path.toString()));
-        String[] locationArray = locations.toArray(new String[0]);
-        
-        splits.add(new FileSplit(path, 0, length, locationArray));
-      }
-      
-      LOG.info("Created {} rack-aware InputSplits from {} HFiles", 
-        splits.size(), hfilePaths.size());
-      
-      return splits;
-    }
-    
-  }
-
   /**
    * Sets up the actual job.
    * @param args The command line parameters.
@@ -213,16 +105,11 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
     job.getConfiguration().setBoolean(HFileOutputFormat2.EXTENDED_CELL_SERIALIZATION_ENABLED_KEY,
       true);
     job.setJarByClass(MapReduceHFileSplitterJob.class);
-    
-    // BACKWARD COMPATIBLE: Choose InputFormat based on configuration
-    if (isRackAwarenessConfigured(conf)) {
-      LOG.info("Using RackAwareHFileInputFormat with pluggable classes");
-      job.setInputFormatClass(RackAwareHFileInputFormat.class);
-    } else {
-      LOG.info("Using standard HFileInputFormat");
-      job.setInputFormatClass(HFileInputFormat.class);
-    }
-    
+
+    // Use standard HFileInputFormat which now supports location resolver automatically
+    // HFileInputFormat will automatically detect and log rack-awareness configuration
+    job.setInputFormatClass(HFileInputFormat.class);
+
     job.setMapOutputKeyClass(ImmutableBytesWritable.class);
     String hfileOutPath = conf.get(BULK_OUTPUT_CONF_KEY);
     if (hfileOutPath != null) {
@@ -249,14 +136,6 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
   }
 
   /**
-   * Check if rack awareness is configured
-   * Location resolver should be configured for effective rack awareness
-   */
-  private boolean isRackAwarenessConfigured(Configuration conf) {
-    return conf.get(CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS) != null;
-  }
-
-  /**
    * Print usage
    * @param errorMsg Error message. Can be null.
    */
@@ -274,9 +153,9 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
       + "=jobName - use the specified mapreduce job name for the HFile splitter");
 
     System.err.println("Rack-aware processing option:");
-    System.err.println("  -D" + CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS + "=<class> - " + 
-      "HFile location resolver class for rack-aware processing");
-    
+    System.err.println("  -D" + HFileInputFormat.CONF_HFILE_LOCATION_RESOLVER_CLASS + "=<class> - "
+      + "HFile location resolver class for rack-aware processing");
+
     System.err.println("For performance also consider the following options:\n"
       + "  -Dmapreduce.map.speculative=false\n" + "  -Dmapreduce.reduce.speculative=false");
   }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceHFileSplitterJob.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceHFileSplitterJob.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hbase.mapreduce.TableMapReduceUtil;
 import org.apache.hadoop.hbase.snapshot.SnapshotRegionLocator;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.MapReduceExtendedCell;
-import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
@@ -110,10 +109,10 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
     /**
      * Get preferred locations for a group of HFiles to optimize rack-aware processing.
      * 
-     * @param hfiles Collection of HFile paths and sizes that will be processed together
+     * @param hfiles Collection of HFile paths that will be processed together
      * @return Set of preferred host names for processing these HFiles
      */
-    Set<String> getLocationsForInputFiles(final Collection<Pair<String, Long>> hfiles);
+    Set<String> getLocationsForInputFiles(final Collection<String> hfiles);
   }
 
 
@@ -123,7 +122,7 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
    */
   public static class NoopHFileLocationResolver implements HFileLocationResolver {
     @Override
-    public Set<String> getLocationsForInputFiles(Collection<Pair<String, Long>> hfiles) {
+    public Set<String> getLocationsForInputFiles(Collection<String> hfiles) {
       // No location hints - lets YARN scheduler decide
       return Collections.emptySet();
     }
@@ -154,9 +153,9 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
       
       // 1. Get all HFiles from input paths
       List<FileStatus> files = listStatus(context);
-      Collection<Pair<String, Long>> hfiles = new ArrayList<>();
+      Collection<String> hfilePaths = new ArrayList<>();
       for (FileStatus file : files) {
-        hfiles.add(new Pair<>(file.getPath().toString(), file.getLen()));
+        hfilePaths.add(file.getPath().toString());
       }
       
       // 2. Load pluggable FileLocationResolver
@@ -170,9 +169,9 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
       // 3. Create InputSplits directly - one per file
       List<InputSplit> splits = new ArrayList<>();
       
-      for (Pair<String, Long> hfile : hfiles) {
-        Path path = new Path(hfile.getFirst());
-        long length = hfile.getSecond();
+      for (FileStatus file : files) {
+        Path path = file.getPath();
+        long length = file.getLen();
         
         if (length <= 0) {
           LOG.warn("Skipping empty or invalid HFile: {} with length: {}", path, length);
@@ -181,14 +180,14 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
         
         // Get location hints for this individual file
         Set<String> locations = fileLocationResolver.getLocationsForInputFiles(
-          Collections.singletonList(hfile));
+          Collections.singletonList(path.toString()));
         String[] locationArray = locations.toArray(new String[0]);
         
         splits.add(new FileSplit(path, 0, length, locationArray));
       }
       
       LOG.info("Created {} rack-aware InputSplits from {} HFiles", 
-        splits.size(), hfiles.size());
+        splits.size(), hfilePaths.size());
       
       return splits;
     }
@@ -273,8 +272,7 @@ public class MapReduceHFileSplitterJob extends Configured implements Tool {
     System.err.println("Other options:");
     System.err.println("   -D " + JOB_NAME_CONF_KEY
       + "=jobName - use the specified mapreduce job name for the HFile splitter");
-    
-    // NEW: Pluggable class options
+
     System.err.println("Rack-aware processing option:");
     System.err.println("  -D" + CONF_INPUT_FILE_LOCATION_RESOLVER_CLASS + "=<class> - " + 
       "HFile location resolver class for rack-aware processing");

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackup.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackup.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -68,6 +69,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.apache.hbase.thirdparty.com.google.common.base.Throwables;
 import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileInputFormat.java
@@ -19,8 +19,11 @@ package org.apache.hadoop.hbase.mapreduce;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.OptionalLong;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -39,6 +42,7 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +55,36 @@ import org.slf4j.LoggerFactory;
 public class HFileInputFormat extends FileInputFormat<NullWritable, Cell> {
 
   private static final Logger LOG = LoggerFactory.getLogger(HFileInputFormat.class);
+
+  // Configuration key for pluggable location resolver class name
+  // Used to enable rack-aware processing by providing preferred data locality hints
+  public static final String CONF_HFILE_LOCATION_RESOLVER_CLASS =
+    "hfile.backup.input.file.location.resolver.class";
+
+  /**
+   * Interface for resolving file locations to influence InputSplit placement for HFile processing.
+   */
+  @InterfaceAudience.Public
+  public interface HFileLocationResolver {
+    /**
+     * Get preferred locations for a group of HFiles to optimize rack-aware processing.
+     * @param hfiles Collection of HFile paths that will be processed together
+     * @return Set of preferred host names for processing these HFiles
+     */
+    Set<String> getLocationsForInputFiles(final Collection<String> hfiles);
+  }
+
+  /**
+   * Default no-op implementation of HFileLocationResolver. Provides backward compatibility by
+   * returning no location hints.
+   */
+  public static class NoopHFileLocationResolver implements HFileLocationResolver {
+    @Override
+    public Set<String> getLocationsForInputFiles(Collection<String> hfiles) {
+      // No location hints - lets YARN scheduler decide
+      return Collections.emptySet();
+    }
+  }
 
   /**
    * File filter that removes all "hidden" files. This might be something worth removing from a more
@@ -183,4 +217,61 @@ public class HFileInputFormat extends FileInputFormat<NullWritable, Cell> {
     // This file isn't splittable.
     return false;
   }
+
+  @Override
+  public List<InputSplit> getSplits(JobContext context) throws IOException {
+    Configuration conf = context.getConfiguration();
+
+    // Check if location resolver is configured
+    String resolverClass = conf.get(CONF_HFILE_LOCATION_RESOLVER_CLASS);
+    if (resolverClass == null) {
+      LOG.debug("HFile rack-aware processing disabled - no location resolver configured");
+      return super.getSplits(context);
+    }
+
+    LOG.info("HFile rack-aware processing enabled with location resolver: {}", resolverClass);
+    try {
+      return createLocationAwareSplits(context, conf);
+    } catch (Exception e) {
+      LOG.error("Error creating location-aware splits, falling back to standard splits", e);
+      return super.getSplits(context);
+    }
+  }
+
+  private List<InputSplit> createLocationAwareSplits(JobContext context, Configuration conf)
+    throws IOException {
+    // Get all HFiles from input paths using existing listStatus logic
+    List<FileStatus> files = listStatus(context);
+
+    // Load configured location resolver
+    Class<? extends HFileLocationResolver> resolverClass =
+      conf.getClass(CONF_HFILE_LOCATION_RESOLVER_CLASS, NoopHFileLocationResolver.class,
+        HFileLocationResolver.class);
+    HFileLocationResolver fileLocationResolver = ReflectionUtils.newInstance(resolverClass, conf);
+
+    // Create InputSplits with location hints
+    List<InputSplit> splits = new ArrayList<>();
+
+    for (FileStatus file : files) {
+      Path path = file.getPath();
+      long length = file.getLen();
+
+      if (length <= 0) {
+        LOG.warn("Skipping empty or invalid HFile: {} with length: {}", path, length);
+        continue;
+      }
+
+      // Get location hints for this file
+      Set<String> locations =
+        fileLocationResolver.getLocationsForInputFiles(Collections.singletonList(path.toString()));
+      String[] locationArray = locations.toArray(new String[0]);
+
+      splits.add(new FileSplit(path, 0, length, locationArray));
+    }
+
+    LOG.info("Created {} location-aware InputSplits from {} HFiles", splits.size(), files.size());
+
+    return splits;
+  }
+
 }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALInputFormat.java
@@ -361,16 +361,16 @@ public class WALInputFormat extends InputFormat<WALKey, WALEdit> {
     List<InputSplit> splits = new ArrayList<>();
     for (FileStatus file : allFiles) {
       // Get locations for this specific WAL file
-      String[] locations = locationResolver.getLocationsForWALFiles(
-        Collections.singletonList(file.getPath().toString())).toArray(new String[0]);
-      
-      splits.add(new WALSplit(file.getPath().toString(), file.getLen(), 
-                             startTime, endTime, locations));
+      String[] locations = locationResolver
+        .getLocationsForWALFiles(Collections.singletonList(file.getPath().toString()))
+        .toArray(new String[0]);
+
+      splits
+        .add(new WALSplit(file.getPath().toString(), file.getLen(), startTime, endTime, locations));
     }
 
     return splits;
   }
-
 
   private Path[] getInputPaths(Configuration conf) {
     String inpDirs = conf.get(FileInputFormat.INPUT_DIR);

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALInputFormat.java
@@ -24,7 +24,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
@@ -361,15 +360,11 @@ public class WALInputFormat extends InputFormat<WALKey, WALEdit> {
 
     List<InputSplit> splits = new ArrayList<>();
     for (FileStatus file : allFiles) {
-      // Convert to format compatible with location resolver
-      org.apache.hadoop.hbase.util.Pair<String, Long> walFile = 
-        new org.apache.hadoop.hbase.util.Pair<>(file.getPath().toString(), file.getLen());
-      
       // Get locations for this specific WAL file
       String[] locations = locationResolver.getLocationsForWALFiles(
-        Collections.singletonList(walFile)).toArray(new String[0]);
+        Collections.singletonList(file.getPath().toString())).toArray(new String[0]);
       
-      splits.add(new WALSplit(walFile.getFirst(), walFile.getSecond(), 
+      splits.add(new WALSplit(file.getPath().toString(), file.getLen(), 
                              startTime, endTime, locations));
     }
 

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -51,6 +52,7 @@ import org.apache.hadoop.hbase.snapshot.SnapshotRegionLocator;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.MapReduceExtendedCell;
+import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.wal.WALEdit;
 import org.apache.hadoop.hbase.wal.WALKey;
 import org.apache.hadoop.mapreduce.Job;
@@ -62,6 +64,7 @@ import org.apache.hadoop.util.ToolRunner;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 
 /**
  * A tool to replay WAL files as a M/R job. The WAL can be replayed for a set of tables or all
@@ -84,6 +87,26 @@ public class WALPlayer extends Configured implements Tool {
   protected static final String tableSeparator = ";";
 
   private final static String JOB_NAME_CONF_KEY = "mapreduce.job.name";
+
+  // Configuration keys
+  public static final String CONF_WAL_FILE_LOCATION_RESOLVER_CLASS =
+    "wal.backup.file.location.resolver.class";
+
+  /**
+   * Interface for resolving file locations to influence InputSplit placement for rack-aware WAL
+   * processing.
+   */
+  @InterfaceAudience.Public
+  public interface WALFileLocationResolver {
+    Set<String> getLocationsForWALFiles(final Collection<Pair<String, Long>> walFiles);
+  }
+
+  public static class NoopWALFileLocationResolver implements WALFileLocationResolver {
+    @Override
+    public Set<String> getLocationsForWALFiles(Collection<Pair<String, Long>> walFiles) {
+      return ImmutableSet.of();
+    }
+  }
 
   public WALPlayer() {
   }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.util.ToolRunner;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 
 /**
@@ -87,7 +88,8 @@ public class WALPlayer extends Configured implements Tool {
 
   private final static String JOB_NAME_CONF_KEY = "mapreduce.job.name";
 
-  // Configuration keys
+  // Configuration key for pluggable WAL location resolver class name
+  // Used to enable rack-aware processing by providing preferred data locality hints for WAL files
   public static final String CONF_WAL_FILE_LOCATION_RESOLVER_CLASS =
     "wal.backup.file.location.resolver.class";
 

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -52,7 +52,6 @@ import org.apache.hadoop.hbase.snapshot.SnapshotRegionLocator;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.MapReduceExtendedCell;
-import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.wal.WALEdit;
 import org.apache.hadoop.hbase.wal.WALKey;
 import org.apache.hadoop.mapreduce.Job;
@@ -98,12 +97,12 @@ public class WALPlayer extends Configured implements Tool {
    */
   @InterfaceAudience.Public
   public interface WALFileLocationResolver {
-    Set<String> getLocationsForWALFiles(final Collection<Pair<String, Long>> walFiles);
+    Set<String> getLocationsForWALFiles(final Collection<String> walFiles);
   }
 
   public static class NoopWALFileLocationResolver implements WALFileLocationResolver {
     @Override
-    public Set<String> getLocationsForWALFiles(Collection<Pair<String, Long>> walFiles) {
+    public Set<String> getLocationsForWALFiles(Collection<String> walFiles) {
       return ImmutableSet.of();
     }
   }


### PR DESCRIPTION
In order to reduce cost of cross AZ transfers, it should support rack awareness in incremental backups.

Added pluggable interfaces for WAL processing and Bulk loads to make incremental backups rack aware.

cc: @charlesconnell 