### PR TITLE
fix reducer count for HFileOutputFormat2 (not upstream yet)

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hbase.regionserver.HStoreFile.BULKLOAD_TASK_KEY;
 import static org.apache.hadoop.hbase.regionserver.HStoreFile.BULKLOAD_TIME_KEY;
 import static org.apache.hadoop.hbase.regionserver.HStoreFile.EXCLUDE_FROM_MINOR_COMPACTION_KEY;
 import static org.apache.hadoop.hbase.regionserver.HStoreFile.MAJOR_COMPACTION_KEY;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -582,6 +582,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
         "First region of table should have empty start key. Instead has: "
           + Bytes.toStringBinary(first.get()));
     }
+    int numPartitions = sorted.size();
     sorted.remove(sorted.first());
 
     // Write the actual file
@@ -604,7 +605,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
       writer.close();
     }
 
-    return sorted.size();
+    return numPartitions;
   }
 
   /**

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -21,7 +21,6 @@ import static org.apache.hadoop.hbase.regionserver.HStoreFile.BULKLOAD_TASK_KEY;
 import static org.apache.hadoop.hbase.regionserver.HStoreFile.BULKLOAD_TIME_KEY;
 import static org.apache.hadoop.hbase.regionserver.HStoreFile.EXCLUDE_FROM_MINOR_COMPACTION_KEY;
 import static org.apache.hadoop.hbase.regionserver.HStoreFile.MAJOR_COMPACTION_KEY;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
@@ -560,7 +559,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
    * contains the split points in startKeys.
    */
   @SuppressWarnings("deprecation")
-  private static void writePartitions(Configuration conf, Path partitionsPath,
+  private static int writePartitions(Configuration conf, Path partitionsPath,
     List<ImmutableBytesWritable> startKeys, boolean writeMultipleTables) throws IOException {
     LOG.info("Writing partition information to " + partitionsPath);
     if (startKeys.isEmpty()) {
@@ -603,6 +602,8 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
     } finally {
       writer.close();
     }
+
+    return sorted.size();
   }
 
   /**
@@ -719,9 +720,9 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
     // Use table's region boundaries for TOP split points.
     LOG.info("Configuring " + startKeys.size() + " reduce partitions "
       + "to match current region count for all tables");
-    job.setNumReduceTasks(startKeys.size());
 
-    configurePartitioner(job, startKeys, writeMultipleTables);
+    int numPartitions = configurePartitioner(job, startKeys, writeMultipleTables);
+    job.setNumReduceTasks(numPartitions);
     // Set compression algorithms based on column families
 
     conf.set(COMPRESSION_FAMILIES_CONF_KEY,
@@ -943,7 +944,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
    * Configure <code>job</code> with a TotalOrderPartitioner, partitioning against
    * <code>splitPoints</code>. Cleans up the partitions file after job exists.
    */
-  static void configurePartitioner(Job job, List<ImmutableBytesWritable> splitPoints,
+  static int configurePartitioner(Job job, List<ImmutableBytesWritable> splitPoints,
     boolean writeMultipleTables) throws IOException {
     Configuration conf = job.getConfiguration();
     // create the partitions file
@@ -952,12 +953,14 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
       conf.get(HConstants.TEMPORARY_FS_DIRECTORY_KEY, HConstants.DEFAULT_TEMPORARY_HDFS_DIRECTORY);
     Path partitionsPath = new Path(hbaseTmpFsDir, "partitions_" + UUID.randomUUID());
     fs.makeQualified(partitionsPath);
-    writePartitions(conf, partitionsPath, splitPoints, writeMultipleTables);
+    int numPartitions = writePartitions(conf, partitionsPath, splitPoints, writeMultipleTables);
     fs.deleteOnExit(partitionsPath);
 
     // configure job to use it
     job.setPartitionerClass(TotalOrderPartitioner.class);
     TotalOrderPartitioner.setPartitionFile(conf, partitionsPath);
+
+    return numPartitions;
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressWarnings(


### PR DESCRIPTION
We started seeing errors when doing incremental backups

```
2025-09-29 19:31:19.527  [main] INFO  org.apache.hadoop.mapreduce.Job - Task Id : attempt_1759167518321_0143_m_000000_0, Status : FAILED
Error: java.lang.IllegalArgumentException: Can't read partitions file
	at org.apache.hadoop.mapreduce.lib.partition.TotalOrderPartitioner.setConf(TotalOrderPartitioner.java:117)
	at org.apache.hadoop.util.ReflectionUtils.setConf(ReflectionUtils.java:79)
	at org.apache.hadoop.util.ReflectionUtils.newInstance(ReflectionUtils.java:140)
	at org.apache.hadoop.mapred.MapTask$NewOutputCollector.<init>(MapTask.java:715)
	at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:783)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:348)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:178)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:714)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:525)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1899)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:172)
Caused by: java.io.IOException: Wrong number of partitions in keyset
	at org.apache.hadoop.mapreduce.lib.partition.TotalOrderPartitioner.setConf(TotalOrderPartitioner.java:91)
	... 10 more
```

The root cause is that the SnapshotRegionLocator which is used as the RegionLocator for modern backups can return dupe start keys in the case of region splits. 

`HFileOutputFormat2` will do two things 

1. Configure the number of reducers based on the # of start keys that we get from _all_ region locations
2. De-dupe the start keys and write the partitions based on the de-duped set 

When this happens, the TotalOrderPartitioner fails because it's expecting the same number of reducers are partitions. Initially, I thought that SnapshotRegionLocator should handle the de-duplication, maybe filtering out any daughter regions. However, the RL docs [specify that getAllRegionsLocations](https://github.com/HubSpot/hbase/blob/0a20a3eb9972262b0da861f8002aa02c9fcdc3a8/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionLocator.java#L122) should fetch all regions associated with the table. Therefore, I think we need to fix the HFileOutputFormat2 to handle the possibility of multiple start keys. 

