### PR TITLE
(DO NOT UPSTREAM) Update incremental backups to support skipping log roll

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos;
 
@@ -170,6 +169,8 @@ public class BackupInfo implements Comparable<BackupInfo> {
    */
   private boolean noChecksumVerify;
 
+  private boolean usePreviousLogRoll = false;
+
   public BackupInfo() {
     backupTableInfoMap = new HashMap<>();
   }
@@ -209,6 +210,14 @@ public class BackupInfo implements Comparable<BackupInfo> {
 
   public boolean getNoChecksumVerify() {
     return noChecksumVerify;
+  }
+
+  public void setUsePreviousLogRoll(boolean usePreviousLogRoll) {
+    this.usePreviousLogRoll = usePreviousLogRoll;
+  }
+
+  public boolean getUsePreviousLogRoll() {
+    return usePreviousLogRoll;
   }
 
   public void setBackupTableInfoMap(Map<TableName, BackupTableInfo> backupTableInfoMap) {

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRequest.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRequest.java
@@ -75,6 +75,11 @@ public final class BackupRequest {
       return this;
     }
 
+    public Builder withUsePreviousLogRoll(boolean usePreviousLogRoll) {
+      request.setUsePreviousLogRoll(usePreviousLogRoll);
+      return this;
+    }
+
     public BackupRequest build() {
       return request;
     }
@@ -89,6 +94,7 @@ public final class BackupRequest {
   private boolean noChecksumVerify = false;
   private String backupSetName;
   private String yarnPoolName;
+  private boolean usePreviousLogRoll = false;
 
   private BackupRequest() {
   }
@@ -162,5 +168,13 @@ public final class BackupRequest {
 
   public void setYarnPoolName(String yarnPoolName) {
     this.yarnPoolName = yarnPoolName;
+  }
+
+  private void setUsePreviousLogRoll(boolean usePreviousLogRoll) {
+    this.usePreviousLogRoll = usePreviousLogRoll;
+  }
+
+  public boolean getUsePreviousLogRoll() {
+    return this.usePreviousLogRoll;
   }
 }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
@@ -581,7 +581,8 @@ public class BackupAdminImpl implements BackupAdmin {
     request = builder.withBackupType(request.getBackupType()).withTableList(tableList)
       .withTargetRootDir(request.getTargetRootDir()).withBackupSetName(request.getBackupSetName())
       .withTotalTasks(request.getTotalTasks()).withBandwidthPerTasks((int) request.getBandwidth())
-      .withNoChecksumVerify(request.getNoChecksumVerify()).build();
+      .withNoChecksumVerify(request.getNoChecksumVerify())
+      .withUsePreviousLogRoll(request.getUsePreviousLogRoll()).build();
 
     TableBackupClient client;
     try {

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
@@ -200,6 +200,24 @@ public class BackupManager implements Closeable {
   public BackupInfo createBackupInfo(String backupId, BackupType type, List<TableName> tableList,
     String targetRootDir, int workers, long bandwidth, boolean noChecksumVerify)
     throws BackupException {
+    return createBackupInfo(backupId, type, tableList, targetRootDir, workers, bandwidth,
+      noChecksumVerify, false);
+  }
+
+  /**
+   * Creates a backup info based on input backup request with optional provided timestamps.
+   * @param backupId           backup id
+   * @param type               type
+   * @param tableList          table list
+   * @param targetRootDir      root dir
+   * @param workers            number of parallel workers
+   * @param bandwidth              bandwidth per worker in MB per sec
+   * @param noChecksumVerify       whether to skip checksum verification
+   * @throws BackupException exception
+   */
+  public BackupInfo createBackupInfo(String backupId, BackupType type, List<TableName> tableList,
+    String targetRootDir, int workers, long bandwidth, boolean noChecksumVerify,
+    boolean usePreviousLogRoll) throws BackupException {
     if (targetRootDir == null) {
       throw new BackupException("Wrong backup request parameter: target backup root directory");
     }
@@ -237,6 +255,7 @@ public class BackupManager implements Closeable {
     backupInfo.setBandwidth(bandwidth);
     backupInfo.setWorkers(workers);
     backupInfo.setNoChecksumVerify(noChecksumVerify);
+    backupInfo.setUsePreviousLogRoll(usePreviousLogRoll);
     return backupInfo;
   }
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalBackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalBackupManager.java
@@ -83,13 +83,17 @@ public class IncrementalBackupManager extends BackupManager {
         + "In order to create an incremental backup, at least one full backup is needed.");
     }
 
-    LOG.info("Execute roll log procedure for incremental backup ...");
-    HashMap<String, String> props = new HashMap<>();
-    props.put("backupRoot", backupInfo.getBackupRootDir());
+    if (backupInfo.getUsePreviousLogRoll()) {
+      LOG.info("Using previous WAL roll for backup, skipping WAL roll procedure");
+    } else {
+      LOG.info("Execute roll log procedure for incremental backup ...");
+      HashMap<String, String> props = new HashMap<>();
+      props.put("backupRoot", backupInfo.getBackupRootDir());
 
-    try (Admin admin = conn.getAdmin()) {
-      admin.execProcedure(LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_SIGNATURE,
-        LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_NAME, props);
+      try (Admin admin = conn.getAdmin()) {
+        admin.execProcedure(LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_SIGNATURE,
+          LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_NAME, props);
+      }
     }
     newTimestamps = readRegionServerLastLogRollResult();
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/TableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/TableBackupClient.java
@@ -92,7 +92,7 @@ public abstract class TableBackupClient {
     this.fs = CommonFSUtils.getCurrentFileSystem(conf);
     backupInfo = backupManager.createBackupInfo(backupId, request.getBackupType(), tableList,
       request.getTargetRootDir(), request.getTotalTasks(), request.getBandwidth(),
-      request.getNoChecksumVerify());
+      request.getNoChecksumVerify(), request.getUsePreviousLogRoll());
     if (tableList == null || tableList.isEmpty()) {
       this.tableList = new ArrayList<>(backupInfo.getTables());
     }


### PR DESCRIPTION
This is a temporary feature that will let us align incremental backups and full backups to within ~minutes of each other, greatly reducing the amount of discrepancies due to time drift between the backups.
With a smaller window of discrepancies, the problem of weeding out the false positives becomes more manageable; I have a couple ideas I'm still trying on that front.