### PR TITLE
HubSpot Edit (not yet upstreamed): Preserve WAL edit order

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos;
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
@@ -206,13 +206,13 @@ public class BackupManager implements Closeable {
 
   /**
    * Creates a backup info based on input backup request with optional provided timestamps.
-   * @param backupId           backup id
-   * @param type               type
-   * @param tableList          table list
-   * @param targetRootDir      root dir
-   * @param workers            number of parallel workers
-   * @param bandwidth              bandwidth per worker in MB per sec
-   * @param noChecksumVerify       whether to skip checksum verification
+   * @param backupId         backup id
+   * @param type             type
+   * @param tableList        table list
+   * @param targetRootDir    root dir
+   * @param workers          number of parallel workers
+   * @param bandwidth        bandwidth per worker in MB per sec
+   * @param noChecksumVerify whether to skip checksum verification
    * @throws BackupException exception
    */
   public BackupInfo createBackupInfo(String backupId, BackupType type, List<TableName> tableList,

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -756,6 +756,11 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
     // SerializationFactory runs through serializations in the order they are registered.
     // We want to register ExtendedCellSerialization before CellSerialization because both
     // work for ExtendedCells but only ExtendedCellSerialization handles them properly.
+
+    if (diskBasedSortingEnabled(conf)) {
+      serializations.add(OrderPreservedExtendedCellSerialization.class.getName());
+    }
+
     if (
       conf.getBoolean(EXTENDED_CELL_SERIALIZATION_ENABLED_KEY,
         EXTENDED_CELL_SERIALIZATION_ENABLED_DEFULT)

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/OrderPreservedExtendedCellSerialization.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/OrderPreservedExtendedCellSerialization.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.mapreduce;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.KeyValueUtil;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.OrderPreservedMapReduceExtendedCell;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.Serialization;
+import org.apache.hadoop.io.serializer.Serializer;
+
+public class OrderPreservedExtendedCellSerialization
+  implements Serialization<OrderPreservedMapReduceExtendedCell> {
+
+  @Override
+  public boolean accept(Class<?> c) {
+    return OrderPreservedMapReduceExtendedCell.class.isAssignableFrom(c);
+  }
+
+  @Override
+  public Serializer<OrderPreservedMapReduceExtendedCell>
+    getSerializer(Class<OrderPreservedMapReduceExtendedCell> c) {
+    return new OrderPreservedExtendedCellSerializer();
+  }
+
+  @Override
+  public Deserializer<OrderPreservedMapReduceExtendedCell>
+    getDeserializer(Class<OrderPreservedMapReduceExtendedCell> c) {
+    return new OrderPreservedExtendedCellDeserializer();
+  }
+
+  public static class OrderPreservedExtendedCellSerializer
+    implements Serializer<OrderPreservedMapReduceExtendedCell> {
+    private DataOutputStream dos;
+
+    @Override
+    public void open(OutputStream os) throws IOException {
+      this.dos = new DataOutputStream(os);
+    }
+
+    @Override
+    public void serialize(OrderPreservedMapReduceExtendedCell kv) throws IOException {
+      dos.writeInt(PrivateCellUtil.estimatedSerializedSizeOf(kv) - Bytes.SIZEOF_INT);
+      PrivateCellUtil.writeCell(kv, dos, true);
+      dos.writeLong(kv.getSequenceId());
+      dos.writeInt(kv.getOrder());
+    }
+
+    @Override
+    public void close() throws IOException {
+      dos.close();
+    }
+  }
+
+  public static class OrderPreservedExtendedCellDeserializer
+    implements Deserializer<OrderPreservedMapReduceExtendedCell> {
+    private DataInputStream dis;
+
+    @Override
+    public void open(InputStream is) throws IOException {
+      this.dis = new DataInputStream(is);
+    }
+
+    @Override
+    public OrderPreservedMapReduceExtendedCell
+      deserialize(OrderPreservedMapReduceExtendedCell ignore) throws IOException {
+      KeyValue kv = KeyValueUtil.create(this.dis);
+      PrivateCellUtil.setSequenceId(kv, this.dis.readLong());
+      int order = dis.readInt();
+      return new OrderPreservedMapReduceExtendedCell(kv, order);
+    }
+
+    @Override
+    public void close() throws IOException {
+      dis.close();
+    }
+  }
+}

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/OrderPreservedExtendedCellSerialization.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/OrderPreservedExtendedCellSerialization.java
@@ -30,7 +30,9 @@ import org.apache.hadoop.hbase.util.OrderPreservedMapReduceExtendedCell;
 import org.apache.hadoop.io.serializer.Deserializer;
 import org.apache.hadoop.io.serializer.Serialization;
 import org.apache.hadoop.io.serializer.Serializer;
+import org.apache.yetus.audience.InterfaceAudience;
 
+@InterfaceAudience.Private
 public class OrderPreservedExtendedCellSerialization
   implements Serialization<OrderPreservedMapReduceExtendedCell> {
 

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
@@ -18,25 +18,37 @@
 package org.apache.hadoop.hbase.mapreduce;
 
 import java.io.IOException;
+import java.util.Comparator;
+import java.util.TreeSet;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.util.MapReduceExtendedCell;
+import org.apache.hadoop.hbase.util.OrderPreservedMapReduceExtendedCell;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @InterfaceAudience.Private
-public class PreSortedCellsReducer
-  extends Reducer<KeyOnlyCellComparable, Cell, ImmutableBytesWritable, Cell> {
+public class PreSortedCellsReducer extends Reducer<KeyOnlyCellComparable,
+  OrderPreservedMapReduceExtendedCell, ImmutableBytesWritable, Cell> {
+  private static final Logger LOG = LoggerFactory.getLogger(PreSortedCellsReducer.class);
 
   @Override
-  protected void reduce(KeyOnlyCellComparable key, Iterable<Cell> values, Context context)
+  protected void reduce(KeyOnlyCellComparable key,
+    Iterable<OrderPreservedMapReduceExtendedCell> values, Context context)
     throws IOException, InterruptedException {
 
+    TreeSet<OrderPreservedMapReduceExtendedCell> cells =
+      new TreeSet<>(Comparator.comparingInt(OrderPreservedMapReduceExtendedCell::getOrder));
+
+    for (OrderPreservedMapReduceExtendedCell cell : values) {
+      cells.add(cell);
+    }
+
     int index = 0;
-    for (Cell cell : values) {
-      context.write(new ImmutableBytesWritable(CellUtil.cloneRow(key.getCell())),
-        new MapReduceExtendedCell(cell));
+    for (OrderPreservedMapReduceExtendedCell cell : cells.descendingSet()) {
+      context.write(new ImmutableBytesWritable(CellUtil.cloneRow(key.getCell())), cell);
 
       if (++index % 100 == 0) {
         context.setStatus("Wrote " + index + " cells");

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
@@ -26,13 +26,10 @@ import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.util.OrderPreservedMapReduceExtendedCell;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.yetus.audience.InterfaceAudience;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @InterfaceAudience.Private
 public class PreSortedCellsReducer extends Reducer<KeyOnlyCellComparable,
   OrderPreservedMapReduceExtendedCell, ImmutableBytesWritable, Cell> {
-  private static final Logger LOG = LoggerFactory.getLogger(PreSortedCellsReducer.class);
 
   @Override
   protected void reduce(KeyOnlyCellComparable key,

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hbase.mapreduce;
 
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.TreeSet;
+import java.util.PriorityQueue;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
@@ -36,15 +36,15 @@ public class PreSortedCellsReducer extends Reducer<KeyOnlyCellComparable,
     Iterable<OrderPreservedMapReduceExtendedCell> values, Context context)
     throws IOException, InterruptedException {
 
-    TreeSet<OrderPreservedMapReduceExtendedCell> cells =
-      new TreeSet<>(Comparator.comparingInt(OrderPreservedMapReduceExtendedCell::getOrder));
+    PriorityQueue<OrderPreservedMapReduceExtendedCell> cells =
+      new PriorityQueue<>(Comparator.comparingInt(OrderPreservedMapReduceExtendedCell::getOrder).reversed());
 
     for (OrderPreservedMapReduceExtendedCell cell : values) {
       cells.add(cell);
     }
 
     int index = 0;
-    for (OrderPreservedMapReduceExtendedCell cell : cells.descendingSet()) {
+    for (OrderPreservedMapReduceExtendedCell cell : cells) {
       context.write(new ImmutableBytesWritable(CellUtil.cloneRow(key.getCell())), cell);
 
       if (++index % 100 == 0) {

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
@@ -40,7 +40,9 @@ public class PreSortedCellsReducer extends Reducer<KeyOnlyCellComparable,
       Comparator.comparingInt(OrderPreservedMapReduceExtendedCell::getOrder).reversed());
 
     for (OrderPreservedMapReduceExtendedCell cell : values) {
-      cells.add(cell);
+      OrderPreservedMapReduceExtendedCell copy =
+        new OrderPreservedMapReduceExtendedCell(cell.deepClone(), cell.getOrder());
+      cells.add(copy);
     }
 
     int index = 0;

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/PreSortedCellsReducer.java
@@ -36,8 +36,8 @@ public class PreSortedCellsReducer extends Reducer<KeyOnlyCellComparable,
     Iterable<OrderPreservedMapReduceExtendedCell> values, Context context)
     throws IOException, InterruptedException {
 
-    PriorityQueue<OrderPreservedMapReduceExtendedCell> cells =
-      new PriorityQueue<>(Comparator.comparingInt(OrderPreservedMapReduceExtendedCell::getOrder).reversed());
+    PriorityQueue<OrderPreservedMapReduceExtendedCell> cells = new PriorityQueue<>(
+      Comparator.comparingInt(OrderPreservedMapReduceExtendedCell::getOrder).reversed());
 
     for (OrderPreservedMapReduceExtendedCell cell : values) {
       cells.add(cell);

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.hbase.snapshot.SnapshotRegionLocator;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.MapReduceExtendedCell;
+import org.apache.hadoop.hbase.util.OrderPreservedMapReduceExtendedCell;
 import org.apache.hadoop.hbase.wal.WALEdit;
 import org.apache.hadoop.hbase.wal.WALKey;
 import org.apache.hadoop.io.WritableComparable;
@@ -174,6 +175,7 @@ public class WALPlayer extends Configured implements Tool {
       try {
         TableName table = key.getTableName();
         if (tableSet.contains(table.getNameAsString())) {
+          int order = 0;
           for (Cell cell : value.getCells()) {
             if (WALEdit.isMetaEditFamily(cell)) {
               continue;
@@ -189,7 +191,8 @@ public class WALPlayer extends Configured implements Tool {
               ? Bytes.add(table.getName(), Bytes.toBytes(tableSeparator), CellUtil.cloneRow(cell))
               : CellUtil.cloneRow(cell);
             ExtendedCell extendedCell = (ExtendedCell) cell;
-            context.write(wrapKey(outKey, extendedCell), new MapReduceExtendedCell(extendedCell));
+            context.write(wrapKey(outKey, extendedCell), wrapCell(extendedCell, order));
+            ++order;
           }
         }
       } catch (InterruptedException e) {
@@ -204,6 +207,13 @@ public class WALPlayer extends Configured implements Tool {
       this.multiTableSupport = conf.getBoolean(MULTI_TABLES_SUPPORT, false);
       this.diskBasedSortingEnabled = HFileOutputFormat2.diskBasedSortingEnabled(conf);
       Collections.addAll(tableSet, tables);
+    }
+
+    private MapReduceExtendedCell wrapCell(ExtendedCell cell, int order) {
+      if (this.diskBasedSortingEnabled) {
+        return new OrderPreservedMapReduceExtendedCell(cell, order);
+      }
+      return new MapReduceExtendedCell(cell);
     }
 
     private WritableComparable<?> wrapKey(byte[] key, ExtendedCell cell) {
@@ -423,12 +433,13 @@ public class WALPlayer extends Configured implements Tool {
       job.setMapperClass(WALCellMapper.class);
       if (diskBasedSortingEnabled) {
         job.setReducerClass(PreSortedCellsReducer.class);
+        job.setMapOutputValueClass(OrderPreservedMapReduceExtendedCell.class);
       } else {
+        job.setMapOutputValueClass(MapReduceExtendedCell.class);
         job.setReducerClass(CellSortReducer.class);
       }
       Path outputDir = new Path(hfileOutPath);
       FileOutputFormat.setOutputPath(job, outputDir);
-      job.setMapOutputValueClass(MapReduceExtendedCell.class);
       try (Connection conn = ConnectionFactory.createConnection(conf);) {
         List<TableInfo> tableInfoList = new ArrayList<>();
         for (TableName tableName : tableNames) {

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/util/OrderPreservedMapReduceExtendedCell.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/util/OrderPreservedMapReduceExtendedCell.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.util;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class OrderPreservedMapReduceExtendedCell extends MapReduceExtendedCell {
+
+  private final int order;
+
+  public OrderPreservedMapReduceExtendedCell(Cell cell, int order) {
+    super(cell);
+    this.order = order;
+  }
+
+  public int getOrder() {
+    return order;
+  }
+}

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
@@ -28,7 +28,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
@@ -328,6 +327,55 @@ public class TestWALPlayer {
   @Test
   public void testWALKeyValueMapperWithDeprecatedConfig() throws Exception {
     testWALKeyValueMapper("hlog.input.tables");
+  }
+
+  @Test
+  public void testInsertionOrderPreserved() throws Exception {
+    final TableName tableName1 = TableName.valueOf(name.getMethodName() + "1");
+    final TableName tableName2 = TableName.valueOf(name.getMethodName() + "2");
+    final byte[] FAMILY = Bytes.toBytes("family");
+    final byte[] COLUMN = Bytes.toBytes("c1");
+    final byte[] ROW = Bytes.toBytes("row");
+    Table t1 = TEST_UTIL.createTable(tableName1, FAMILY);
+    Table t2 = TEST_UTIL.createTable(tableName2, FAMILY);
+
+    // put a row into the first table
+    Put p = new Put(ROW);
+    p.addColumn(FAMILY, COLUMN, Bytes.toBytes("aaa"));
+    p.addColumn(FAMILY, COLUMN, Bytes.toBytes("zzz"));
+    t1.put(p);
+
+    // replay the WAL, map table 1 to table 2
+    WAL log = cluster.getRegionServer(0).getWAL(null);
+    log.rollWriter();
+    String walInputDir = new Path(cluster.getMaster().getMasterFileSystem().getWALRootDir(),
+      HConstants.HREGION_LOGDIR_NAME).toString();
+
+    Configuration configuration = TEST_UTIL.getConfiguration();
+    WALPlayer player = new WALPlayer(configuration);
+
+    configuration.setBoolean(HFileOutputFormat2.DISK_BASED_SORTING_ENABLED_KEY, true);
+
+    try {
+      String optionName = "_test_.name";
+      configuration.set(optionName, "1000");
+      player.setupTime(configuration, optionName);
+      String outPath = "/tmp/" + name.getMethodName();
+      configuration.set(WALPlayer.BULK_OUTPUT_CONF_KEY, outPath);
+      assertEquals(1000, configuration.getLong(optionName, 0));
+      assertEquals(0, ToolRunner.run(configuration, player,
+        new String[] { walInputDir, tableName1.getNameAsString(), tableName2.getNameAsString() }));
+
+      BulkLoadHFiles.create(configuration).bulkLoad(tableName2, new Path(outPath));
+
+      Get g = new Get(ROW);
+      Result r = t2.get(g);
+      Cell cell = r.getColumnLatestCell(FAMILY, COLUMN);
+      String value = Bytes.toString(CellUtil.cloneValue(cell));
+      assertEquals("zzz", value);
+    } finally {
+      configuration.unset(HFileOutputFormat2.DISK_BASED_SORTING_ENABLED_KEY);
+    }
   }
 
   private void testWALKeyValueMapper(final String tableConfigKey) throws Exception {


### PR DESCRIPTION
We've discovered that inter-put edits lose their ordering when we convert WAL files to HFiles using a MR job. The reducer doesn't provide any ordering guarantees of the values being sorted lexigraphically. That means if the client does 

```
Put put = new Put(row);
put.setColumnValue(CF, QF, "aaa", 123L);
put.setColumnValue(CF, QF, "zzz", 123L);
client.put(put);
```

Even though their "latest" edit for CF + CQ is "zzz", a snapshot scan over an incremental backup (and if we restore the table prior to the next full backup) will return "aaa". When you query HBase, though, it returns "aaa". 

This PR aims to address this problem by encoding the ordering into the cell value. This has been branch-deployed and has resolved data inconsistencies when comparing snapshot scans from a full backup vs a modern backup 