### PR TITLE
Fix walplayer mapping (not yet upstream)

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -66,7 +66,6 @@ import org.apache.hadoop.util.ToolRunner;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 
 /**
@@ -418,7 +417,7 @@ public class WALPlayer extends Configured implements Tool {
     if (hfileOutPath != null) {
       LOG.debug("add incremental job :" + hfileOutPath + " from " + inputDirs);
 
-      if (!multiTableSupport && tables.length != 1) {
+      if (!multiTableSupport && tableMap.length != 1) {
         throw new IOException("Exactly one table must be specified for the bulk export option");
       }
 
@@ -428,7 +427,7 @@ public class WALPlayer extends Configured implements Tool {
         true);
 
       // the bulk HFile case
-      List<TableName> tableNames = getTableNameList(tables);
+      List<TableName> tableNames = getTableNameList(tableMap);
 
       job.setMapperClass(WALCellMapper.class);
       if (diskBasedSortingEnabled) {

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -66,6 +66,7 @@ import org.apache.hadoop.util.ToolRunner;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 
 /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionLocator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionLocator.java
@@ -54,7 +54,6 @@ public final class SnapshotRegionLocator implements RegionLocator {
     ServerName.parseServerName("www.example.net,1234,1212121212");
 
   private final TableName tableName;
-  private final SnapshotManifest manifest;
   private final TreeMap<byte[], HRegionReplicas> regions;
 
   private final List<HRegionLocation> rawLocations;
@@ -92,13 +91,12 @@ public final class SnapshotRegionLocator implements RegionLocator {
       replicas.put(key, hrr);
     }
 
-    return new SnapshotRegionLocator(tableName, manifest, replicas, rawLocations);
+    return new SnapshotRegionLocator(tableName, replicas, rawLocations);
   }
 
-  private SnapshotRegionLocator(TableName tableName, SnapshotManifest manifest, TreeMap<byte[], HRegionReplicas> regions,
+  private SnapshotRegionLocator(TableName tableName, TreeMap<byte[], HRegionReplicas> regions,
     List<HRegionLocation> rawLocations) {
     this.tableName = tableName;
-    this.manifest = manifest;
     this.regions = regions;
     this.rawLocations = rawLocations;
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionLocator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionLocator.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
+
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos;
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionLocator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionLocator.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
-
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos;
 
@@ -55,6 +54,7 @@ public final class SnapshotRegionLocator implements RegionLocator {
     ServerName.parseServerName("www.example.net,1234,1212121212");
 
   private final TableName tableName;
+  private final SnapshotManifest manifest;
   private final TreeMap<byte[], HRegionReplicas> regions;
 
   private final List<HRegionLocation> rawLocations;
@@ -92,12 +92,13 @@ public final class SnapshotRegionLocator implements RegionLocator {
       replicas.put(key, hrr);
     }
 
-    return new SnapshotRegionLocator(tableName, replicas, rawLocations);
+    return new SnapshotRegionLocator(tableName, manifest, replicas, rawLocations);
   }
 
-  private SnapshotRegionLocator(TableName tableName, TreeMap<byte[], HRegionReplicas> regions,
+  private SnapshotRegionLocator(TableName tableName, SnapshotManifest manifest, TreeMap<byte[], HRegionReplicas> regions,
     List<HRegionLocation> rawLocations) {
     this.tableName = tableName;
+    this.manifest = manifest;
     this.regions = regions;
     this.rawLocations = rawLocations;
   }
@@ -131,6 +132,10 @@ public final class SnapshotRegionLocator implements RegionLocator {
   @Override
   public void close() throws IOException {
 
+  }
+
+  public SnapshotManifest getManifest() {
+    return manifest;
   }
 
   public static boolean shouldUseSnapshotRegionLocator(Configuration conf, TableName table) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionLocator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionLocator.java
@@ -134,10 +134,6 @@ public final class SnapshotRegionLocator implements RegionLocator {
 
   }
 
-  public SnapshotManifest getManifest() {
-    return manifest;
-  }
-
   public static boolean shouldUseSnapshotRegionLocator(Configuration conf, TableName table) {
     return conf.get(getSnapshotManifestDirKey(table)) != null;
   }


### PR DESCRIPTION
WALPlayer doesn't pass in the correct table mappings when using the bulk output option. This means we won't bulkload to the correct locations. 

This PR bulkloads the tables to target tables in the table mapping when running WALPlayer with bulkloads