### PR TITLE
HubSpot Edit: Dont fail on snapshot timeout (Not yet upstreamed) 

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/FullTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/FullTableBackupClient.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.BackupCopyJob;
@@ -217,8 +218,20 @@ public class FullTableBackupClient extends TableBackupClient {
     int pause = conf.getInt(BACKUP_ATTEMPTS_PAUSE_MS_KEY, DEFAULT_BACKUP_ATTEMPTS_PAUSE_MS);
     int attempts = 0;
 
+    Pattern regex = Pattern.compile(snapshotName);
+
     while (attempts++ < maxAttempts) {
       try {
+        if (
+          admin.listSnapshots(regex).stream()
+            .anyMatch(snapshot -> snapshot.getName().equals(snapshotName))
+        ) {
+          // If a snapshot takes a long time to run, we may get a TimeoutException from the
+          // admin, in that case re-attempts to take a snapshot will always fail b/c we'll
+          // eventually
+          // attempt to take a snapshot with a name that already exists
+          return;
+        }
         admin.snapshot(snapshotName, tableName);
         return;
       } catch (IOException ee) {


### PR DESCRIPTION
The admin can time out trying to take a snapshot if the table is large. If that happens, any attempts at re-trying to take the snapshot will fail. First with "snapshot already in progress for table", and next with "snapshot already exists". 

This patch first checks to see if the snapshot already exists before attempting to take the snapshot again. 

You can see an example of this happening for cicero, [here](https://logs.iad02.k8s.run/namespaces/app-hbasedisasterrecoveryjobs-modernbackup/pods/cronjob-mainline-71160aa9-manual-c7ddf560-sr2wd/created=2025-12-03T13:12:17Z__uid=01a512bd-864b-4f1e-b17a-d1312ba0ee17/containers/app/created=20251203T131225Z__restart=0__id=bdfc38014a0bd76b1c1f566c5d8464f206a9046c4d2ed7cd67f4ba24cdbadf5c/logs/start=20251203T131226Z__end=20251203T132449Z.log.zst?format=PLAIN&compression=VIEW_IN_BROWSER)