### PR TITLE
(Not upstreamed yet) Use async client in FullTableBackupClient

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
@@ -40,11 +40,8 @@ public interface BackupRestoreConstants {
   String BACKUP_ENABLE_KEY = "hbase.backup.enable";
   boolean BACKUP_ENABLE_DEFAULT = false;
 
-  String BACKUP_MAX_ATTEMPTS_KEY = "hbase.backup.attempts.max";
-  int DEFAULT_BACKUP_MAX_ATTEMPTS = 10;
-
-  String BACKUP_ATTEMPTS_PAUSE_MS_KEY = "hbase.backup.attempts.pause.ms";
-  int DEFAULT_BACKUP_ATTEMPTS_PAUSE_MS = 10000;
+  String BACKUP_WAIT_MS_KEY = "hbase.backup.attempts.wait.ms";
+  long DEFAULT_BACKUP_WAIT_MS = 10_000 * 10;
 
   /*
    * Drivers option list

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/FullTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/FullTableBackupClient.java
@@ -17,17 +17,15 @@
  */
 package org.apache.hadoop.hbase.backup.impl;
 
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.BACKUP_ATTEMPTS_PAUSE_MS_KEY;
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.BACKUP_MAX_ATTEMPTS_KEY;
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.DEFAULT_BACKUP_ATTEMPTS_PAUSE_MS;
-import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.DEFAULT_BACKUP_MAX_ATTEMPTS;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.BACKUP_WAIT_MS_KEY;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.DEFAULT_BACKUP_WAIT_MS;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.JOB_NAME_CONF_KEY;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.BackupCopyJob;
@@ -41,6 +39,8 @@ import org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager;
 import org.apache.hadoop.hbase.backup.util.BackupUtils;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.SnapshotDescription;
+import org.apache.hadoop.hbase.client.SnapshotType;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
@@ -213,27 +213,18 @@ public class FullTableBackupClient extends TableBackupClient {
 
   protected void snapshotTable(Admin admin, TableName tableName, String snapshotName)
     throws IOException {
-    int maxAttempts = conf.getInt(BACKUP_MAX_ATTEMPTS_KEY, DEFAULT_BACKUP_MAX_ATTEMPTS);
-    int pause = conf.getInt(BACKUP_ATTEMPTS_PAUSE_MS_KEY, DEFAULT_BACKUP_ATTEMPTS_PAUSE_MS);
-    int attempts = 0;
+    long waitMs = conf.getLong(BACKUP_WAIT_MS_KEY, DEFAULT_BACKUP_WAIT_MS);
+    SnapshotDescription desc = new SnapshotDescription(snapshotName, tableName, SnapshotType.FLUSH);
 
-    while (attempts++ < maxAttempts) {
-      try {
-        admin.snapshot(snapshotName, tableName);
-        return;
-      } catch (IOException ee) {
-        LOG.warn("Snapshot attempt " + attempts + " failed for table " + tableName
-          + ", sleeping for " + pause + "ms", ee);
-        if (attempts < maxAttempts) {
-          try {
-            Thread.sleep(pause);
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            break;
-          }
-        }
-      }
+    try {
+      admin.snapshotAsync(desc).get(waitMs, TimeUnit.MILLISECONDS);
+
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to snapshot " + snapshotName + " to " + tableName, e);
     }
-    throw new IOException("Failed to snapshot table " + tableName);
+
+    if (!admin.isSnapshotFinished(desc)) {
+      throw new IOException("Snapshot " + snapshotName + " not finished.");
+    }
   }
 }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/FullTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/FullTableBackupClient.java
@@ -20,16 +20,13 @@ package org.apache.hadoop.hbase.backup.impl;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.BACKUP_WAIT_MS_KEY;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.DEFAULT_BACKUP_WAIT_MS;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.JOB_NAME_CONF_KEY;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-<<<<<<< HEAD
 import java.util.concurrent.TimeUnit;
-=======
-import java.util.regex.Pattern;
->>>>>>> 5c35dad9c74f426c4ecece4fd8d13e630089f231
 import java.util.stream.Collectors;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.BackupCopyJob;


### PR DESCRIPTION
Use an async call to take the snapshot so we don't need to do any weird looping. this is simpler