### PR TITLE
HBASE-29827: BackupTables should return BackupInfo (Not yet upstream)

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupAdmin.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupAdmin.java
@@ -39,10 +39,10 @@ public interface BackupAdmin extends Closeable {
    * Backup given list of tables fully. This is a synchronous operation. It returns backup id on
    * success or throw exception on failure.
    * @param userRequest BackupRequest instance
-   * @return the backup Id
+   * @return backup info
    */
 
-  String backupTables(final BackupRequest userRequest) throws IOException;
+  BackupInfo backupTables(final BackupRequest userRequest) throws IOException;
 
   /**
    * Restore backup

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
@@ -510,7 +510,7 @@ public class BackupAdminImpl implements BackupAdmin {
   }
 
   @Override
-  public String backupTables(BackupRequest request) throws IOException {
+  public BackupInfo backupTables(BackupRequest request) throws IOException {
     BackupType type = request.getBackupType();
     String targetRootDir = request.getTargetRootDir();
     List<TableName> tableList = request.getTableList();
@@ -594,7 +594,7 @@ public class BackupAdminImpl implements BackupAdmin {
 
     client.execute();
 
-    return backupId;
+    return client.getBackupInfo();
   }
 
   private List<TableName> excludeNonExistingTables(List<TableName> tableList,

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -43,7 +43,6 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKE
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME_DESC;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -68,7 +67,6 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.yetus.audience.InterfaceAudience;
-
 import org.apache.hbase.thirdparty.com.google.common.base.Splitter;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
@@ -367,7 +365,7 @@ public final class BackupCommands {
           .withTargetRootDir(targetBackupDir).withTotalTasks(workers)
           .withBandwidthPerTasks(bandwidth).withNoChecksumVerify(ignoreChecksum)
           .withBackupSetName(setName).build();
-        String backupId = admin.backupTables(request);
+        String backupId = admin.backupTables(request).getBackupId();
         System.out.println("Backup session " + backupId + " finished. Status: SUCCESS");
       } catch (IOException e) {
         System.out.println("Backup session finished. Status: FAILURE");

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/TableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/TableBackupClient.java
@@ -100,6 +100,10 @@ public abstract class TableBackupClient {
     backupManager.startBackupSession();
   }
 
+  public BackupInfo getBackupInfo() {
+    return backupInfo;
+  }
+
   /**
    * Begin the overall backup.
    * @param backupInfo backup info

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupBase.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupBase.java
@@ -414,7 +414,7 @@ public class TestBackupBase {
       conn = ConnectionFactory.createConnection(conf1);
       badmin = new BackupAdminImpl(conn);
       BackupRequest request = createBackupRequest(type, new ArrayList<>(tables), path);
-      backupId = badmin.backupTables(request);
+      backupId = badmin.backupTables(request).getBackupId();
     } finally {
       if (badmin != null) {
         badmin.close();

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupMerge.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupMerge.java
@@ -64,7 +64,7 @@ public class TestBackupMerge extends TestBackupBase {
     BackupAdminImpl client = new BackupAdminImpl(conn);
 
     BackupRequest request = createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR);
-    String backupIdFull = client.backupTables(request);
+    String backupIdFull = client.backupTables(request).getBackupId();
 
     assertTrue(checkSucceeded(backupIdFull));
 
@@ -85,7 +85,7 @@ public class TestBackupMerge extends TestBackupBase {
     // #3 - incremental backup for multiple tables
     tables = Lists.newArrayList(table1, table2);
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdIncMultiple = client.backupTables(request);
+    String backupIdIncMultiple = client.backupTables(request).getBackupId();
 
     assertTrue(checkSucceeded(backupIdIncMultiple));
 
@@ -97,7 +97,7 @@ public class TestBackupMerge extends TestBackupBase {
 
     // #3 - incremental backup for multiple tables
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdIncMultiple2 = client.backupTables(request);
+    String backupIdIncMultiple2 = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdIncMultiple2));
 
     try (BackupAdmin bAdmin = new BackupAdminImpl(conn)) {
@@ -139,15 +139,15 @@ public class TestBackupMerge extends TestBackupBase {
       List<TableName> tables = Lists.newArrayList(table1, table2);
 
       BackupRequest request = createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR, true);
-      String backupIdFull = client.backupTables(request);
+      String backupIdFull = client.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(backupIdFull));
 
       request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR, true);
-      String backupIdIncMultiple = client.backupTables(request);
+      String backupIdIncMultiple = client.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(backupIdIncMultiple));
 
       request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR, true);
-      String backupIdIncMultiple2 = client.backupTables(request);
+      String backupIdIncMultiple2 = client.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(backupIdIncMultiple2));
 
       try (BackupAdmin bAdmin = new BackupAdminImpl(conn)) {

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupMultipleDeletes.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupMultipleDeletes.java
@@ -63,7 +63,7 @@ public class TestBackupMultipleDeletes extends TestBackupBase {
     Admin admin = conn.getAdmin();
     BackupAdmin client = new BackupAdminImpl(conn);
     BackupRequest request = createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR);
-    String backupIdFull = client.backupTables(request);
+    String backupIdFull = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdFull));
     // #2 - insert some data to table table1
     Table t1 = conn.getTable(table1);
@@ -78,7 +78,7 @@ public class TestBackupMultipleDeletes extends TestBackupBase {
     // #3 - incremental backup for table1
     tables = Lists.newArrayList(table1);
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdInc1 = client.backupTables(request);
+    String backupIdInc1 = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdInc1));
     // #4 - insert some data to table table2
     Table t2 = conn.getTable(table2);
@@ -91,7 +91,7 @@ public class TestBackupMultipleDeletes extends TestBackupBase {
     // #5 - incremental backup for table1, table2
     tables = Lists.newArrayList(table1, table2);
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdInc2 = client.backupTables(request);
+    String backupIdInc2 = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdInc2));
     // #6 - insert some data to table table1
     t1 = conn.getTable(table1);
@@ -103,7 +103,7 @@ public class TestBackupMultipleDeletes extends TestBackupBase {
     // #7 - incremental backup for table1
     tables = Lists.newArrayList(table1);
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdInc3 = client.backupTables(request);
+    String backupIdInc3 = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdInc3));
     // #8 - insert some data to table table2
     t2 = conn.getTable(table2);
@@ -115,17 +115,17 @@ public class TestBackupMultipleDeletes extends TestBackupBase {
     // #9 - incremental backup for table1, table2
     tables = Lists.newArrayList(table1, table2);
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdInc4 = client.backupTables(request);
+    String backupIdInc4 = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdInc4));
     // #10 full backup for table3
     tables = Lists.newArrayList(table3);
     request = createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR);
-    String backupIdFull2 = client.backupTables(request);
+    String backupIdFull2 = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdFull2));
     // #11 - incremental backup for table3
     tables = Lists.newArrayList(table3);
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdInc5 = client.backupTables(request);
+    String backupIdInc5 = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdInc5));
     LOG.error("Delete backupIdInc2");
     client.deleteBackups(new String[] { backupIdInc2 });

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRestoreOnEmptyEnvironment.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRestoreOnEmptyEnvironment.java
@@ -220,7 +220,7 @@ public class TestBackupRestoreOnEmptyEnvironment {
       BackupRequest backupRequest =
         new BackupRequest.Builder().withTargetRootDir(BACKUP_ROOT_DIR.toString())
           .withTableList(new ArrayList<>(tables)).withBackupType(backupType).build();
-      return backupAdmin.backupTables(backupRequest);
+      return backupAdmin.backupTables(backupRequest).getBackupId();
     }
 
   }

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRestoreWithModifications.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRestoreWithModifications.java
@@ -217,7 +217,7 @@ public class TestBackupRestoreWithModifications {
       BackupRequest backupRequest =
         new BackupRequest.Builder().withTargetRootDir(BACKUP_ROOT_DIR.toString())
           .withTableList(new ArrayList<>(tables)).withBackupType(backupType).build();
-      return backupAdmin.backupTables(backupRequest);
+      return backupAdmin.backupTables(backupRequest).getBackupId();
     }
 
   }

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackup.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackup.java
@@ -200,7 +200,7 @@ public class TestIncrementalBackup extends TestBackupBase {
       // #3 - incremental backup for multiple tables
       tables = Lists.newArrayList(table1, table2);
       request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-      String backupIdIncMultiple = client.backupTables(request);
+      String backupIdIncMultiple = client.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(backupIdIncMultiple));
       BackupManifest manifest =
         HBackupFileSystem.getManifest(conf1, new Path(BACKUP_ROOT_DIR), backupIdIncMultiple);
@@ -231,7 +231,7 @@ public class TestIncrementalBackup extends TestBackupBase {
 
       // #4 - additional incremental backup for multiple tables
       request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-      String backupIdIncMultiple2 = client.backupTables(request);
+      String backupIdIncMultiple2 = client.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(backupIdIncMultiple2));
       validateRootPathCanBeOverridden(BACKUP_ROOT_DIR, backupIdIncMultiple2);
 
@@ -299,7 +299,7 @@ public class TestIncrementalBackup extends TestBackupBase {
     Connection conn = TEST_UTIL.getConnection();
     BackupAdminImpl backupAdmin = new BackupAdminImpl(conn);
     BackupRequest request = createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR);
-    String fullBackupId = backupAdmin.backupTables(request);
+    String fullBackupId = backupAdmin.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(fullBackupId));
 
     TableName[] fromTables = new TableName[] { table1 };
@@ -332,7 +332,7 @@ public class TestIncrementalBackup extends TestBackupBase {
       assertNotEquals(currentRegions, TEST_UTIL.getHBaseCluster().getRegions(table1));
 
       request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-      String incrementalBackupId = backupAdmin.backupTables(request);
+      String incrementalBackupId = backupAdmin.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(incrementalBackupId));
       preRestoreBackupFiles = getBackupFiles();
       backupAdmin.restore(BackupUtils.createRestoreRequest(BACKUP_ROOT_DIR, incrementalBackupId,
@@ -364,7 +364,7 @@ public class TestIncrementalBackup extends TestBackupBase {
       }
 
       request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-      incrementalBackupId = backupAdmin.backupTables(request);
+      incrementalBackupId = backupAdmin.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(incrementalBackupId));
 
       preRestoreBackupFiles = getBackupFiles();
@@ -404,7 +404,7 @@ public class TestIncrementalBackup extends TestBackupBase {
 
       BackupRequest request =
         createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR, true);
-      String incrementalBackupId = admin.backupTables(request);
+      String incrementalBackupId = admin.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(incrementalBackupId));
 
       TableName[] fromTable = new TableName[] { table1 };
@@ -483,7 +483,7 @@ public class TestIncrementalBackup extends TestBackupBase {
 
       BackupRequest request =
         createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR, true);
-      String incrementalBackupId = admin.backupTables(request);
+      String incrementalBackupId = admin.backupTables(request).getBackupId();
       assertTrue(checkSucceeded(incrementalBackupId));
 
       TableName[] fromTable = new TableName[] { table1 };
@@ -514,7 +514,7 @@ public class TestIncrementalBackup extends TestBackupBase {
     boolean noChecksumVerify) throws IOException {
     BackupRequest req =
       createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR, noChecksumVerify);
-    String backupId = backupAdmin.backupTables(req);
+    String backupId = backupAdmin.backupTables(req).getBackupId();
     checkSucceeded(backupId);
     return backupId;
   }

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupDeleteTable.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupDeleteTable.java
@@ -65,7 +65,7 @@ public class TestIncrementalBackupDeleteTable extends TestBackupBase {
     BackupAdminImpl client = new BackupAdminImpl(conn);
 
     BackupRequest request = createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR);
-    String backupIdFull = client.backupTables(request);
+    String backupIdFull = client.backupTables(request).getBackupId();
 
     assertTrue(checkSucceeded(backupIdFull));
 
@@ -88,7 +88,7 @@ public class TestIncrementalBackupDeleteTable extends TestBackupBase {
     // #3 - incremental backup for table1
     tables = Lists.newArrayList(table1);
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdIncMultiple = client.backupTables(request);
+    String backupIdIncMultiple = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdIncMultiple));
 
     // #4 - restore full backup for all tables, without overwrite

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupMergeWithBulkLoad.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupMergeWithBulkLoad.java
@@ -216,7 +216,7 @@ public class TestIncrementalBackupMergeWithBulkLoad {
       BackupRequest backupRequest =
         new BackupRequest.Builder().withTargetRootDir(BACKUP_ROOT_DIR.toString())
           .withTableList(new ArrayList<>(tables)).withBackupType(backupType).build();
-      return backupAdmin.backupTables(backupRequest);
+      return backupAdmin.backupTables(backupRequest).getBackupId();
     }
   }
 

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupMergeWithFailures.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupMergeWithFailures.java
@@ -240,7 +240,7 @@ public class TestIncrementalBackupMergeWithFailures extends TestBackupBase {
     BackupAdminImpl client = new BackupAdminImpl(conn);
 
     BackupRequest request = createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR);
-    String backupIdFull = client.backupTables(request);
+    String backupIdFull = client.backupTables(request).getBackupId();
 
     assertTrue(checkSucceeded(backupIdFull));
 
@@ -261,7 +261,7 @@ public class TestIncrementalBackupMergeWithFailures extends TestBackupBase {
     // #3 - incremental backup for multiple tables
     tables = Lists.newArrayList(table1, table2);
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdIncMultiple = client.backupTables(request);
+    String backupIdIncMultiple = client.backupTables(request).getBackupId();
 
     assertTrue(checkSucceeded(backupIdIncMultiple));
 
@@ -273,7 +273,7 @@ public class TestIncrementalBackupMergeWithFailures extends TestBackupBase {
 
     // #3 - incremental backup for multiple tables
     request = createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR);
-    String backupIdIncMultiple2 = client.backupTables(request);
+    String backupIdIncMultiple2 = client.backupTables(request).getBackupId();
     assertTrue(checkSucceeded(backupIdIncMultiple2));
     // #4 Merge backup images with failures
 

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupWithDataLoss.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupWithDataLoss.java
@@ -54,11 +54,12 @@ public class TestIncrementalBackupWithDataLoss extends TestBackupBase {
       List<TableName> tables = Lists.newArrayList(table1);
 
       insertIntoTable(conn, table1, famName, 1, 1).close();
-      String backup1 =
-        client.backupTables(createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR));
+      String backup1 = client
+        .backupTables(createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR)).getBackupId();
       insertIntoTable(conn, table1, famName, 2, 1).close();
       String backup2 =
-        client.backupTables(createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR));
+        client.backupTables(createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR))
+          .getBackupId();
 
       assertTrue(checkSucceeded(backup1));
       assertTrue(checkSucceeded(backup2));
@@ -67,14 +68,16 @@ public class TestIncrementalBackupWithDataLoss extends TestBackupBase {
       TEST_UTIL.getTestFileSystem().delete(new Path(BACKUP_ROOT_DIR, backup2), true);
 
       insertIntoTable(conn, table1, famName, 4, 1).close();
-      String backup4 =
-        client.backupTables(createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR));
+      String backup4 = client
+        .backupTables(createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR)).getBackupId();
       insertIntoTable(conn, table1, famName, 5, 1).close();
       String backup5 =
-        client.backupTables(createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR));
+        client.backupTables(createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR))
+          .getBackupId();
       insertIntoTable(conn, table1, famName, 6, 1).close();
       String backup6 =
-        client.backupTables(createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR));
+        client.backupTables(createBackupRequest(BackupType.INCREMENTAL, tables, BACKUP_ROOT_DIR))
+          .getBackupId();
 
       assertTrue(checkSucceeded(backup4));
       assertTrue(checkSucceeded(backup5));

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupWithFailures.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupWithFailures.java
@@ -95,7 +95,7 @@ public class TestIncrementalBackupWithFailures extends TestBackupBase {
     BackupAdminImpl client = new BackupAdminImpl(conn);
 
     BackupRequest request = createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR);
-    String backupIdFull = client.backupTables(request);
+    String backupIdFull = client.backupTables(request).getBackupId();
 
     assertTrue(checkSucceeded(backupIdFull));
 

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
@@ -229,7 +229,7 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
   }
 
   private String backup(BackupRequest request, BackupAdmin client) throws IOException {
-    String backupId = client.backupTables(request);
+    String backupId = client.backupTables(request).getBackupId();
     return backupId;
   }
 


### PR DESCRIPTION
Will make it easier for us to track which files have been included in the incremental backups. We can use the BackupInfo#getIncrBackupFileList which is only set in memory during backup execution, and can't be fetched querying the system table.