### PR TITLE
HubSpot Backport HBASE-29796 Allow sleepForRetry replication config to be overridden by replication peers

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/PeerProcedureHandlerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/PeerProcedureHandlerImpl.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.replication.regionserver;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.replication.ReplicationException;
@@ -98,6 +99,33 @@ public class PeerProcedureHandlerImpl implements PeerProcedureHandler {
     refreshPeerState(peerId);
   }
 
+  private boolean hasReplicationConfigChange(ReplicationPeerConfig oldConfig,
+    ReplicationPeerConfig newConfig) {
+    Map<String, String> oldReplicationConfigs = oldConfig.getConfiguration();
+    Map<String, String> newReplicationConfigs = newConfig.getConfiguration();
+
+    // Check if any replication.source.* keys have changed values
+    for (Map.Entry<String, String> entry : newReplicationConfigs.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith("replication.source.")) {
+        String oldValue = oldReplicationConfigs.get(key);
+        String newValue = entry.getValue();
+        if (!newValue.equals(oldValue)) {
+          return true;
+        }
+      }
+    }
+
+    // Check if any replication.source.* keys were removed
+    for (String key : oldReplicationConfigs.keySet()) {
+      if (key.startsWith("replication.source.") && !newReplicationConfigs.containsKey(key)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   @Override
   public void updatePeerConfig(String peerId) throws ReplicationException, IOException {
     Lock peerLock = peersLock.acquireLock(peerId);
@@ -121,6 +149,7 @@ public class PeerProcedureHandlerImpl implements PeerProcedureHandler {
       if (
         !ReplicationUtils.isNamespacesAndTableCFsEqual(oldConfig, newConfig)
           || oldConfig.isSerial() != newConfig.isSerial()
+          || hasReplicationConfigChange(oldConfig, newConfig)
           || (oldState.equals(PeerState.ENABLED) && newState.equals(PeerState.DISABLED))
       ) {
         replicationSourceManager.refreshSources(peerId);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
@@ -834,4 +834,8 @@ public class ReplicationSource implements ReplicationSourceInterface {
   public long getTotalReplicatedEdits() {
     return totalReplicatedEdits.get();
   }
+
+  long getSleepForRetries() {
+    return sleepForRetries;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceShipper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceShipper.java
@@ -371,4 +371,8 @@ public class ReplicationSourceShipper extends Thread {
         totalReleasedBytes);
     }
   }
+
+  long getSleepForRetries() {
+    return sleepForRetries;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceWALReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceWALReader.java
@@ -440,4 +440,8 @@ class ReplicationSourceWALReader extends Thread {
   private ReplicationSourceManager getSourceManager() {
     return this.source.getSourceManager();
   }
+
+  long getSleepForRetries() {
+    return sleepForRetries;
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestPeerProcedureHandlerImpl.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestPeerProcedureHandlerImpl.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.replication.regionserver;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.hadoop.hbase.replication.ReplicationPeer.PeerState;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
+import org.apache.hadoop.hbase.replication.ReplicationPeerImpl;
+import org.apache.hadoop.hbase.replication.ReplicationPeers;
+import org.apache.hadoop.hbase.testclassification.ReplicationTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(ReplicationTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestPeerProcedureHandlerImpl {
+
+  private ReplicationSourceManager mockSourceManager;
+  private ReplicationPeers mockReplicationPeers;
+  private ReplicationPeerImpl mockPeer;
+  private PeerProcedureHandlerImpl handler;
+  private static final String PEER_ID = "testPeer";
+
+  @BeforeEach
+  public void setup() throws Exception {
+    mockSourceManager = mock(ReplicationSourceManager.class);
+    mockReplicationPeers = mock(ReplicationPeers.class);
+    mockPeer = mock(ReplicationPeerImpl.class);
+
+    when(mockSourceManager.getReplicationPeers()).thenReturn(mockReplicationPeers);
+    when(mockReplicationPeers.getPeer(PEER_ID)).thenReturn(mockPeer);
+
+    handler = new PeerProcedureHandlerImpl(mockSourceManager);
+  }
+
+  @Test
+  public void testReplicationSourceConfigChangeTriggers() throws Exception {
+    ReplicationPeerConfig oldConfig = ReplicationPeerConfig.newBuilder().setClusterKey("oldCluster")
+      .putConfiguration("replication.source.sleepforretries", "1000").build();
+
+    ReplicationPeerConfig newConfig = ReplicationPeerConfig.newBuilder().setClusterKey("oldCluster")
+      .putConfiguration("replication.source.sleepforretries", "5000").build();
+
+    when(mockPeer.getPeerConfig()).thenReturn(oldConfig);
+    when(mockPeer.getPeerState()).thenReturn(PeerState.ENABLED);
+    when(mockReplicationPeers.refreshPeerConfig(PEER_ID)).thenReturn(newConfig);
+    when(mockReplicationPeers.refreshPeerState(PEER_ID)).thenReturn(PeerState.ENABLED);
+
+    handler.updatePeerConfig(PEER_ID);
+
+    verify(mockSourceManager, times(1)).refreshSources(PEER_ID);
+  }
+
+  @Test
+  public void testNonReplicationSourceConfigDoesNotTrigger() throws Exception {
+    ReplicationPeerConfig oldConfig = ReplicationPeerConfig.newBuilder().setClusterKey("oldCluster")
+      .putConfiguration("some.other.config", "value1").build();
+
+    ReplicationPeerConfig newConfig = ReplicationPeerConfig.newBuilder().setClusterKey("oldCluster")
+      .putConfiguration("some.other.config", "value2").build();
+
+    when(mockPeer.getPeerConfig()).thenReturn(oldConfig);
+    when(mockPeer.getPeerState()).thenReturn(PeerState.ENABLED);
+    when(mockReplicationPeers.refreshPeerConfig(PEER_ID)).thenReturn(newConfig);
+    when(mockReplicationPeers.refreshPeerState(PEER_ID)).thenReturn(PeerState.ENABLED);
+
+    handler.updatePeerConfig(PEER_ID);
+
+    verify(mockSourceManager, never()).refreshSources(anyString());
+  }
+
+  @Test
+  public void testNewReplicationSourceConfigTriggers() throws Exception {
+    ReplicationPeerConfig oldConfig =
+      ReplicationPeerConfig.newBuilder().setClusterKey("oldCluster").build();
+
+    ReplicationPeerConfig newConfig = ReplicationPeerConfig.newBuilder().setClusterKey("oldCluster")
+      .putConfiguration("replication.source.sleepforretries", "5000").build();
+
+    when(mockPeer.getPeerConfig()).thenReturn(oldConfig);
+    when(mockPeer.getPeerState()).thenReturn(PeerState.ENABLED);
+    when(mockReplicationPeers.refreshPeerConfig(PEER_ID)).thenReturn(newConfig);
+    when(mockReplicationPeers.refreshPeerState(PEER_ID)).thenReturn(PeerState.ENABLED);
+
+    handler.updatePeerConfig(PEER_ID);
+
+    verify(mockSourceManager, times(1)).refreshSources(PEER_ID);
+  }
+
+  @Test
+  public void testRemovedReplicationSourceConfigTriggers() throws Exception {
+    ReplicationPeerConfig oldConfig = ReplicationPeerConfig.newBuilder().setClusterKey("oldCluster")
+      .putConfiguration("replication.source.sleepforretries", "2000").build();
+
+    ReplicationPeerConfig newConfig =
+      ReplicationPeerConfig.newBuilder().setClusterKey("oldCluster").build();
+
+    when(mockPeer.getPeerConfig()).thenReturn(oldConfig);
+    when(mockPeer.getPeerState()).thenReturn(PeerState.ENABLED);
+    when(mockReplicationPeers.refreshPeerConfig(PEER_ID)).thenReturn(newConfig);
+    when(mockReplicationPeers.refreshPeerState(PEER_ID)).thenReturn(PeerState.ENABLED);
+
+    handler.updatePeerConfig(PEER_ID);
+
+    verify(mockSourceManager, times(1)).refreshSources(PEER_ID);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestPeerProcedureHandlerImpl.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestPeerProcedureHandlerImpl.java
@@ -30,12 +30,11 @@ import org.apache.hadoop.hbase.replication.ReplicationPeerImpl;
 import org.apache.hadoop.hbase.replication.ReplicationPeers;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-@Tag(ReplicationTests.TAG)
-@Tag(SmallTests.TAG)
+@Category({ ReplicationTests.class, SmallTests.class })
 public class TestPeerProcedureHandlerImpl {
 
   private ReplicationSourceManager mockSourceManager;
@@ -44,7 +43,7 @@ public class TestPeerProcedureHandlerImpl {
   private PeerProcedureHandlerImpl handler;
   private static final String PEER_ID = "testPeer";
 
-  @BeforeEach
+  @Before
   public void setup() throws Exception {
     mockSourceManager = mock(ReplicationSourceManager.class);
     mockReplicationPeers = mock(ReplicationPeers.class);


### PR DESCRIPTION
apache#7577. We don't use the latest version of junit, so I have changed the unit tests to use the older version. That should be the only difference from the branch-2.6 change upstream. Upstream PR description below:

Currently, sleepForRetries (the sleep time between retry attempts during replication) is only configurable globally via the replication.source.sleepforretries configuration property. This makes it impossible to tune behavior for individual replication peers that may have different requirements.

This change would add support for overriding replication source config values on a per-peer basis, with fallback to the global configuration when not set.