### PR TITLE
HBASE-29846 Fix backup history ordering

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupAdmin.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupAdmin.java
@@ -77,10 +77,10 @@ public interface BackupAdmin extends Closeable {
   void mergeBackups(String[] backupIds) throws IOException;
 
   /**
-   * Show backup history command with filters
-   * @param n last n backup sessions
-   * @param f list of filters
-   * @return list of backup info objects
+   * Retrieve info about the most recent backups.
+   * @param n number of backup infos desired
+   * @param f optional filters, only entries passing the filters will be returned
+   * @return a list of at most n entries, ordered from newest (most recent) to oldest (least recent)
    * @throws IOException exception
    */
   List<BackupInfo> getHistory(int n, BackupInfo.Filter... f) throws IOException;

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -44,6 +44,7 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKE
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_WORKERS_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME_DESC;
+import static org.apache.hadoop.hbase.backup.impl.BackupSystemTable.Order.NEW_TO_OLD;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -172,7 +173,8 @@ public final class BackupCommands {
       if (requiresNoActiveSession()) {
         // Check active session
         try (BackupSystemTable table = new BackupSystemTable(conn)) {
-          List<BackupInfo> sessions = table.getBackupInfos(withState(BackupState.RUNNING));
+          List<BackupInfo> sessions =
+            table.getBackupHistory(NEW_TO_OLD, 1, withState(BackupState.RUNNING));
 
           if (sessions.size() > 0) {
             System.err.println("Found backup session in a RUNNING state: ");
@@ -547,7 +549,8 @@ public final class BackupCommands {
         if (backupId != null) {
           info = sysTable.readBackupInfo(backupId);
         } else {
-          List<BackupInfo> infos = sysTable.getBackupInfos(withState(BackupState.RUNNING));
+          List<BackupInfo> infos =
+            sysTable.getBackupHistory(NEW_TO_OLD, 1, withState(BackupState.RUNNING));
           if (infos != null && infos.size() > 0) {
             info = infos.get(0);
             backupId = info.getBackupId();
@@ -695,7 +698,8 @@ public final class BackupCommands {
         final BackupSystemTable sysTable = new BackupSystemTable(conn)) {
         // Failed backup
         BackupInfo backupInfo;
-        List<BackupInfo> list = sysTable.getBackupInfos(withState(BackupState.RUNNING));
+        List<BackupInfo> list =
+          sysTable.getBackupHistory(NEW_TO_OLD, 1, withState(BackupState.RUNNING));
         if (list.size() == 0) {
           // No failed sessions found
           System.out.println("REPAIR status: no failed sessions found."

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.backup.impl;
 
 import static org.apache.hadoop.hbase.backup.BackupInfo.withState;
+import static org.apache.hadoop.hbase.backup.impl.BackupSystemTable.Order.NEW_TO_OLD;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -269,7 +270,8 @@ public class BackupManager implements Closeable {
    * @throws IOException exception
    */
   private String getOngoingBackupId() throws IOException {
-    List<BackupInfo> sessions = systemTable.getBackupInfos(withState(BackupState.RUNNING));
+    List<BackupInfo> sessions =
+      systemTable.getBackupHistory(NEW_TO_OLD, 1, withState(BackupState.RUNNING));
     if (sessions.size() == 0) {
       return null;
     }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -82,6 +81,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 import org.apache.hbase.thirdparty.com.google.common.base.Splitter;
 import org.apache.hbase.thirdparty.com.google.common.collect.Iterators;
 
@@ -598,24 +598,12 @@ public final class BackupSystemTable implements Closeable {
   }
 
   /**
-   * Get all backup information passing the given filters, ordered by descending start time. I.e.
-   * from newest to oldest.
-   */
-  public List<BackupInfo> getBackupHistory(BackupInfo.Filter... toInclude) throws IOException {
-    LOG.trace("get backup history from backup system table");
-
-    List<BackupInfo> list = getBackupInfos(toInclude);
-    list.sort(Comparator.comparing(BackupInfo::getStartTs).reversed());
-    return list;
-  }
-
-  /**
    * Retrieve all table names that are part of any known completed backup
    */
   public Set<TableName> getTablesIncludedInBackups() throws IOException {
     // Incremental backups have the same tables as the preceding full backups
     List<BackupInfo> infos =
-      getBackupInfos(withState(BackupState.COMPLETE), withType(BackupType.FULL));
+      getBackupHistory(withState(BackupState.COMPLETE), withType(BackupType.FULL));
     return infos.stream().flatMap(info -> info.getTableNames().stream())
       .collect(Collectors.toSet());
   }
@@ -647,26 +635,31 @@ public final class BackupSystemTable implements Closeable {
   }
 
   /**
-   * Get all backup infos passing the given filters (ordered by ascending backup id)
+   * Get all backup information passing the given filters, ordered by descending backupId. I.e. from
+   * newest to oldest.
    */
-  public List<BackupInfo> getBackupInfos(BackupInfo.Filter... toInclude) throws IOException {
-    return getBackupInfos(Integer.MAX_VALUE, toInclude);
+  public List<BackupInfo> getBackupHistory(BackupInfo.Filter... toInclude) throws IOException {
+    return getBackupHistory(Order.NEW_TO_OLD, Integer.MAX_VALUE, toInclude);
   }
 
   /**
-   * Get the first n backup infos passing the given filters (ordered by ascending backup id)
+   * Retrieves the first n entries of the sorted, filtered list of backup infos.
+   * @param order desired ordering of the results.
+   * @param n     number of entries to return
    */
-  public List<BackupInfo> getBackupInfos(int n, BackupInfo.Filter... toInclude) throws IOException {
+  public List<BackupInfo> getBackupHistory(Order order, int n, BackupInfo.Filter... toInclude)
+    throws IOException {
+    Preconditions.checkArgument(n >= 0, "n should be >= 0");
     LOG.trace("get backup infos from backup system table");
 
-    if (n <= 0) {
+    if (n == 0) {
       return Collections.emptyList();
     }
 
     Predicate<BackupInfo> combinedPredicate = Stream.of(toInclude)
       .map(filter -> (Predicate<BackupInfo>) filter).reduce(Predicate::and).orElse(x -> true);
 
-    Scan scan = createScanForBackupHistory();
+    Scan scan = createScanForBackupHistory(order);
     List<BackupInfo> list = new ArrayList<>();
 
     try (Table table = connection.getTable(tableName);
@@ -852,21 +845,17 @@ public final class BackupSystemTable implements Closeable {
   /**
    * Checks if we have at least one backup session in backup system table This API is used by
    * BackupLogCleaner
-   * @return true, if - at least one session exists in backup system table table
+   * @return true, if at least one session exists in backup system table
    * @throws IOException exception
    */
   public boolean hasBackupSessions() throws IOException {
     LOG.trace("Has backup sessions from backup system table");
 
-    boolean result = false;
-    Scan scan = createScanForBackupHistory();
+    Scan scan = createScanForBackupHistory(Order.OLD_TO_NEW);
     scan.setCaching(1);
     try (Table table = connection.getTable(tableName);
       ResultScanner scanner = table.getScanner(scan)) {
-      if (scanner.next() != null) {
-        result = true;
-      }
-      return result;
+      return scanner.next() != null;
     }
   }
 
@@ -1190,15 +1179,23 @@ public final class BackupSystemTable implements Closeable {
 
   /**
    * Creates Scan operation to load backup history
+   * @param order order of the scan results
    * @return scan operation
    */
-  private Scan createScanForBackupHistory() {
+  private Scan createScanForBackupHistory(Order order) {
     Scan scan = new Scan();
     byte[] startRow = Bytes.toBytes(BACKUP_INFO_PREFIX);
-    byte[] stopRow = Arrays.copyOf(startRow, startRow.length);
-    stopRow[stopRow.length - 1] = (byte) (stopRow[stopRow.length - 1] + 1);
-    scan.withStartRow(startRow);
-    scan.withStopRow(stopRow);
+    if (order == Order.NEW_TO_OLD) {
+      byte[] stopRow = Arrays.copyOf(startRow, startRow.length);
+      stopRow[stopRow.length - 1] = (byte) (stopRow[stopRow.length - 1] + 1);
+      scan.setReversed(true);
+      scan.withStartRow(stopRow, false);
+      scan.withStopRow(startRow);
+    } else if (order == Order.OLD_TO_NEW) {
+      scan.setStartStopRowForPrefixScan(startRow);
+    } else {
+      throw new IllegalArgumentException("Unsupported order: " + order);
+    }
     scan.addFamily(BackupSystemTable.SESSIONS_FAMILY);
     scan.readVersions(1);
     return scan;
@@ -1652,5 +1649,16 @@ public final class BackupSystemTable implements Closeable {
         LOG.info("Table {} is not disabled, ignoring enable request", tableName);
       }
     }
+  }
+
+  public enum Order {
+    /**
+     * Old backups first, most recents last. I.e. sorted by ascending backupId.
+     */
+    OLD_TO_NEW,
+    /**
+     * New backups first, oldest last. I.e. sorted by descending backupId.
+     */
+    NEW_TO_OLD
   }
 }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/util/BackupUtils.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/util/BackupUtils.java
@@ -533,12 +533,21 @@ public final class BackupUtils {
       + HConstants.HREGION_LOGDIR_NAME;
   }
 
+  /**
+   * Loads all backup history as stored in files on the given backup root path.
+   * @return all backup history, from newest (most recent) to oldest (least recent)
+   */
   private static List<BackupInfo> getHistory(Configuration conf, Path backupRootPath)
     throws IOException {
     // Get all (n) history from backup root destination
 
     FileSystem fs = FileSystem.get(backupRootPath.toUri(), conf);
-    RemoteIterator<LocatedFileStatus> it = fs.listLocatedStatus(backupRootPath);
+    RemoteIterator<LocatedFileStatus> it;
+    try {
+      it = fs.listLocatedStatus(backupRootPath);
+    } catch (FileNotFoundException e) {
+      return Collections.emptyList();
+    }
 
     List<BackupInfo> infos = new ArrayList<>();
     while (it.hasNext()) {
@@ -557,26 +566,15 @@ public final class BackupUtils {
       }
     }
     // Sort
-    Collections.sort(infos, new Comparator<BackupInfo>() {
-      @Override
-      public int compare(BackupInfo o1, BackupInfo o2) {
-        long ts1 = getTimestamp(o1.getBackupId());
-        long ts2 = getTimestamp(o2.getBackupId());
-
-        if (ts1 == ts2) {
-          return 0;
-        }
-
-        return ts1 < ts2 ? 1 : -1;
-      }
-
-      private long getTimestamp(String backupId) {
-        return Long.parseLong(Iterators.get(Splitter.on('_').split(backupId).iterator(), 1));
-      }
-    });
+    infos.sort(Comparator.<BackupInfo> naturalOrder().reversed());
     return infos;
   }
 
+  /**
+   * Loads all backup history as stored in files on the given backup root path, and returns the
+   * first n entries matching all given filters.
+   * @return (subset of) backup history, from newest (most recent) to oldest (least recent)
+   */
   public static List<BackupInfo> getHistory(Configuration conf, int n, Path backupRootPath,
     BackupInfo.Filter... filters) throws IOException {
     List<BackupInfo> infos = getHistory(conf, backupRootPath);

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupShowHistory.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupShowHistory.java
@@ -17,14 +17,15 @@
  */
 package org.apache.hadoop.hbase.backup;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 import org.apache.hadoop.fs.Path;
+import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.util.BackupUtils;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.util.ToolRunner;
@@ -33,8 +34,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 
 @Category(LargeTests.class)
 public class TestBackupShowHistory extends TestBackupBase {
@@ -45,96 +44,100 @@ public class TestBackupShowHistory extends TestBackupBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestBackupShowHistory.class);
 
-  private boolean findBackup(List<BackupInfo> history, String backupId) {
-    assertTrue(history.size() > 0);
-    boolean success = false;
-    for (BackupInfo info : history) {
-      if (info.getBackupId().equals(backupId)) {
-        success = true;
-        break;
-      }
-    }
-    return success;
-  }
-
   /**
-   * Verify that full backup is created on a single table with data correctly. Verify that history
-   * works as expected.
-   * @throws Exception if doing the backup or an operation on the tables fails
+   * Verify that backup history retrieval works as expected.
    */
   @Test
   public void testBackupHistory() throws Exception {
-
     LOG.info("test backup history on a single table with data");
 
-    List<TableName> tableList = Lists.newArrayList(table1);
-    String backupId = fullTableBackup(tableList);
+    // Test without backups present
+    List<BackupInfo> history = getBackupAdmin().getHistory(10);
+    assertEquals(0, history.size());
+
+    history = BackupUtils.getHistory(conf1, 10, new Path(BACKUP_ROOT_DIR));
+    assertEquals(0, history.size());
+
+    // Create first backup
+    String backupId = fullTableBackup(Lists.newArrayList(table1));
     assertTrue(checkSucceeded(backupId));
     LOG.info("backup complete");
 
-    List<BackupInfo> history = getBackupAdmin().getHistory(10);
-    assertTrue(findBackup(history, backupId));
-    history = BackupUtils.getHistory(conf1, 10, new Path(BACKUP_ROOT_DIR));
-    assertTrue(findBackup(history, backupId));
+    // Tests with one backup present
+    history = getBackupAdmin().getHistory(10);
+    assertEquals(1, history.size());
+    assertEquals(backupId, history.get(0).getBackupId());
 
+    history = BackupUtils.getHistory(conf1, 10, new Path(BACKUP_ROOT_DIR));
+    assertEquals(1, history.size());
+    assertEquals(backupId, history.get(0).getBackupId());
+
+    String output = runHistoryCommand(10);
+    assertTrue(output.indexOf(backupId) > 0);
+
+    // Create second backup
+    String backupId2 = fullTableBackup(Lists.newArrayList(table2));
+    assertTrue(checkSucceeded(backupId2));
+    LOG.info("backup complete: " + table2);
+
+    // Test with multiple backups
+    history = getBackupAdmin().getHistory(10);
+    assertEquals(2, history.size());
+    assertEquals(backupId2, history.get(0).getBackupId());
+    assertEquals(backupId, history.get(1).getBackupId());
+
+    history = BackupUtils.getHistory(conf1, 10, new Path(BACKUP_ROOT_DIR));
+    assertEquals(2, history.size());
+    assertEquals(backupId2, history.get(0).getBackupId());
+    assertEquals(backupId, history.get(1).getBackupId());
+
+    output = runHistoryCommand(10);
+    int idx1 = output.indexOf(backupId);
+    int idx2 = output.indexOf(backupId2);
+    assertTrue(idx1 >= 0); // Backup 1 is listed
+    assertTrue(idx2 >= 0); // Backup 2 is listed
+    assertTrue(idx2 < idx1); // Newest backup (Backup 2) comes first
+
+    // Test with multiple backups & n == 1
+    history = getBackupAdmin().getHistory(1);
+    assertEquals(1, history.size());
+    assertEquals(backupId2, history.get(0).getBackupId());
+
+    history = BackupUtils.getHistory(conf1, 1, new Path(BACKUP_ROOT_DIR));
+    assertEquals(1, history.size());
+    assertEquals(backupId2, history.get(0).getBackupId());
+
+    output = runHistoryCommand(1);
+    idx1 = output.indexOf(backupId);
+    idx2 = output.indexOf(backupId2);
+    assertTrue(idx2 > 0); // most recent backup is listed
+    assertEquals(-1, idx1); // second most recent backup isn't listed
+
+    // Test with multiple backups & filtering
+    BackupInfo.Filter tableNameFilter = i -> i.getTableNames().contains(table1);
+
+    history = getBackupAdmin().getHistory(10, tableNameFilter);
+    assertEquals(1, history.size());
+    assertEquals(backupId, history.get(0).getBackupId());
+
+    history = BackupUtils.getHistory(conf1, 10, new Path(BACKUP_ROOT_DIR), tableNameFilter);
+    assertEquals(1, history.size());
+    assertEquals(backupId, history.get(0).getBackupId());
+
+  }
+
+  private String runHistoryCommand(int n) throws Exception {
+    String[] args = new String[] { "history", "-n", String.valueOf(n), "-p", BACKUP_ROOT_DIR };
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     System.setOut(new PrintStream(baos));
 
-    String[] args = new String[] { "history", "-n", "10", "-p", BACKUP_ROOT_DIR };
-    // Run backup
+    LOG.info("Running history command");
     int ret = ToolRunner.run(conf1, new BackupDriver(), args);
-    assertTrue(ret == 0);
-    LOG.info("show_history");
+    assertEquals(0, ret);
+
     String output = baos.toString();
     LOG.info(output);
     baos.close();
-    assertTrue(output.indexOf(backupId) > 0);
-
-    tableList = Lists.newArrayList(table2);
-    String backupId2 = fullTableBackup(tableList);
-    assertTrue(checkSucceeded(backupId2));
-    LOG.info("backup complete: " + table2);
-    BackupInfo.Filter tableNameFilter = image -> {
-      if (table1 == null) {
-        return true;
-      }
-
-      List<TableName> names = image.getTableNames();
-      return names.contains(table1);
-    };
-    BackupInfo.Filter tableSetFilter = info -> {
-      String backupId1 = info.getBackupId();
-      return backupId1.startsWith("backup");
-    };
-
-    history = getBackupAdmin().getHistory(10, tableNameFilter, tableSetFilter);
-    assertTrue(history.size() > 0);
-    boolean success = true;
-    for (BackupInfo info : history) {
-      if (!info.getTableNames().contains(table1)) {
-        success = false;
-        break;
-      }
-    }
-    assertTrue(success);
-
-    history =
-      BackupUtils.getHistory(conf1, 10, new Path(BACKUP_ROOT_DIR), tableNameFilter, tableSetFilter);
-    assertTrue(history.size() > 0);
-    success = true;
-    for (BackupInfo info : history) {
-      if (!info.getTableNames().contains(table1)) {
-        success = false;
-        break;
-      }
-    }
-    assertTrue(success);
-
-    args =
-      new String[] { "history", "-n", "10", "-p", BACKUP_ROOT_DIR, "-t", "table1", "-s", "backup" };
-    // Run backup
-    ret = ToolRunner.run(conf1, new BackupDriver(), args);
-    assertTrue(ret == 0);
-    LOG.info("show_history");
+    return output;
   }
 }


### PR DESCRIPTION
Restores the ordering of BackupAdmin#getHistory that was accidentally reversed in HBASE-29808. Extends & refactors TestBackupShowHistory to verify correct behavior.

Fixes a possible FileNotFoundException in BackupUtils#getHistory.

Merges BackupSystemTable#getBackupHistory with
BackupSystemTable#getBackupInfos, to further simplify backup info retrieval. Optimized various usages of history retrieval.

Clarified some javadoc regarding backup history retrieval.

(cherry picked from commit ed04e2e1fe5c61d744fc08585a2e2cfa6becc6d1)