### PR TITLE
exclude reload4j

### DIFF
--- a/hubspot-client-bundles/hbase-client-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-client-bundle/pom.xml
@@ -50,6 +50,14 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>ch.qos.reload4j</groupId>
+          <artifactId>reload4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
+++ b/hubspot-client-bundles/hbase-mapreduce-bundle/pom.xml
@@ -102,6 +102,14 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>ch.qos.reload4j</groupId>
+          <artifactId>reload4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -190,6 +198,14 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.reload4j</groupId>
+          <artifactId>reload4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.glassfish.hk2.external</groupId>


### PR DESCRIPTION
Trying to solve for https://hubspot.slack.com/archives/C0DGP7SR3/p1779972370137829

Apache HBase/Hadoop ship reload4j as their post-EOL Log4j 1.x binding. It exposes the same org.apache.log4j.* classes as log4j-over-slf4j (the SLF4J shim HubSpot services get from hubspot-logging). The two collide on consumers' classpaths, and when reload4j wins the race, libraries that still use the legacy org.apache.log4j API — e.g. google/keyczar via HubSpot Crypto — bypass Logback entirely and emit unconfigured DEBUG to stdout. That noise is invisible to LogFetch (which only ingests Logback) and immune to the logfetch log-level UI (which only sets SLF4J levels), so it sits on services unnoticed.
