### PR TITLE
(Not upstreamed yet) HBASE-30218 Backup repair permanently holds lock when FULL backup fails in REQUEST phase

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -723,12 +723,19 @@ public final class BackupCommands {
           + backupInfo.getStartTs() + ",failedts=" + backupInfo.getCompleteTs() + ",failedphase="
           + backupInfo.getPhase() + ",failedmessage=" + backupInfo.getFailedMsg();
         System.out.println(backupFailedData);
-        TableBackupClient.cleanupAndRestoreBackupSystem(conn, backupInfo, conf);
-        // If backup session is updated to FAILED state - means we
-        // processed recovery already.
-        sysTable.updateBackupInfo(backupInfo);
-        sysTable.finishBackupExclusiveOperation();
-        System.out.println("REPAIR status: finished repair failed session:\n " + backupInfo);
+        try {
+          TableBackupClient.cleanupAndRestoreBackupSystem(conn, backupInfo, conf);
+          // If backup session is updated to FAILED state - means we
+          // processed recovery already.
+          sysTable.updateBackupInfo(backupInfo);
+          System.out.println("REPAIR status: finished repair failed session:\n " + backupInfo);
+        } finally {
+          try {
+            sysTable.finishBackupExclusiveOperation();
+          } catch (IOException fe) {
+            System.err.println("Failed to finish backup exclusive operation: " + fe.getMessage());
+          }
+        }
       }
     }
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/TableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/TableBackupClient.java
@@ -252,11 +252,16 @@ public abstract class TableBackupClient {
       // If backup session is updated to FAILED state - means we
       // processed recovery already.
       backupManager.updateBackupInfo(backupInfo);
-      backupManager.finishBackupSession();
       LOG.error("Backup " + backupInfo.getBackupId() + " failed.");
     } catch (IOException ee) {
       LOG.error("Please run backup repair tool manually to restore backup system integrity");
       throw ee;
+    } finally {
+      try {
+        backupManager.finishBackupSession();
+      } catch (IOException fe) {
+        LOG.error("Failed to finish backup session", fe);
+      }
     }
   }
 
@@ -267,7 +272,10 @@ public abstract class TableBackupClient {
     // and also clean up export snapshot log files if exist
     if (type == BackupType.FULL) {
       deleteSnapshots(conn, backupInfo, conf);
-      cleanupExportSnapshotLog(conf);
+      BackupPhase phase = backupInfo.getPhase();
+      if (phase == BackupPhase.SNAPSHOTCOPY || phase == BackupPhase.STORE_MANIFEST) {
+        cleanupExportSnapshotLog(conf);
+      }
     }
     BackupSystemTable.restoreFromSnapshot(conn);
     BackupSystemTable.deleteSnapshot(conn);

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java
@@ -81,6 +81,10 @@ public class TestBackupRepair extends TestBackupBase {
       confWithoutRootDir.unset(HConstants.HBASE_DIR);
       TableBackupClient.cleanupAndRestoreBackupSystem(TEST_UTIL.getConnection(), running.get(0),
         confWithoutRootDir);
+
+      List<BackupInfo> stillRunning =
+        sysTable.getBackupHistory(BackupInfo.withState(BackupInfo.BackupState.RUNNING));
+      assertTrue(stillRunning.isEmpty());
     }
   }
 

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java
@@ -22,7 +22,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
 import org.apache.hadoop.hbase.backup.impl.TableBackupClient;
@@ -56,6 +58,28 @@ public class TestBackupRepair extends TestBackupBase {
     for (int stage = 0; stage < maxStage; stage++) {
       LOG.info("Running stage " + stage);
       runBackupAndFailAtStageWithRestore(stage);
+    }
+  }
+
+  @Test
+  public void testRepairDoesNotThrowWhenHbaseRootDirAbsentAndPhaseIsRequest() throws Exception {
+    autoRestoreOnFailure = false;
+    conf1.set(TableBackupClient.BACKUP_CLIENT_IMPL_CLASS,
+      FullTableBackupClientForTest.class.getName());
+    conf1.setInt(FullTableBackupClientForTest.BACKUP_TEST_MODE_STAGE, 0);
+    String[] args =
+      new String[] { "create", "full", BACKUP_ROOT_DIR, "-t", table1.getNameAsString() };
+    int ret = ToolRunner.run(conf1, new BackupDriver(), args);
+    assertFalse(ret == 0);
+
+    try (BackupSystemTable sysTable = new BackupSystemTable(TEST_UTIL.getConnection())) {
+      List<BackupInfo> running =
+        sysTable.getBackupHistory(BackupInfo.withState(BackupInfo.BackupState.RUNNING));
+      assertTrue(running.size() == 1);
+      Configuration confWithoutRootDir = new Configuration(conf1);
+      confWithoutRootDir.unset(HConstants.HBASE_DIR);
+      TableBackupClient.cleanupAndRestoreBackupSystem(TEST_UTIL.getConnection(), running.get(0),
+        confWithoutRootDir);
     }
   }
 

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java
@@ -19,12 +19,10 @@ package org.apache.hadoop.hbase.backup;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
 import org.apache.hadoop.hbase.backup.impl.TableBackupClient;
@@ -63,7 +61,7 @@ public class TestBackupRepair extends TestBackupBase {
 
   /** See HBASE-30218. */
   @Test
-  public void testRepairDoesNotThrowWhenHbaseRootDirAbsentAndPhaseIsRequest() throws Exception {
+  public void testRepairDoesNotThrowWhenStagingRootAbsentAndPhaseIsRequest() throws Exception {
     autoRestoreOnFailure = false;
     conf1.set(TableBackupClient.BACKUP_CLIENT_IMPL_CLASS,
       FullTableBackupClientForTest.class.getName());
@@ -77,10 +75,10 @@ public class TestBackupRepair extends TestBackupBase {
       List<BackupInfo> running =
         sysTable.getBackupHistory(BackupInfo.withState(BackupInfo.BackupState.RUNNING));
       assertTrue(running.size() == 1);
-      Configuration confWithoutRootDir = new Configuration(conf1);
-      confWithoutRootDir.unset(HConstants.HBASE_DIR);
+      Configuration confWithoutStagingRoot = new Configuration(conf1);
+      confWithoutStagingRoot.unset(BackupRestoreConstants.CONF_STAGING_ROOT);
       TableBackupClient.cleanupAndRestoreBackupSystem(TEST_UTIL.getConnection(), running.get(0),
-        confWithoutRootDir);
+        confWithoutStagingRoot);
 
       List<BackupInfo> stillRunning =
         sysTable.getBackupHistory(BackupInfo.withState(BackupInfo.BackupState.RUNNING));

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java
@@ -61,6 +61,7 @@ public class TestBackupRepair extends TestBackupBase {
     }
   }
 
+  /** See HBASE-30218. */
   @Test
   public void testRepairDoesNotThrowWhenHbaseRootDirAbsentAndPhaseIsRequest() throws Exception {
     autoRestoreOnFailure = false;


### PR DESCRIPTION
## Description

See [HBASE-30218](https://issues.apache.org/jira/browse/HBASE-30218).

---

## Changes

* Added a guard in `cleanupAndRestoreBackupSystem` to only run `cleanupExportSnapshotLog` during `SNAPSHOTCOPY` and later; this does not run for backups that died in `REQUEST` or `SNAPSHOT` in which case there's nothing to clean
* Moved `finishBackupSession` into a finally block so that the exclusive lock is always released
* Added the same finally guard in the `BackupCommands repair` path

## Testing

Validated against a test cluster.
1. Inserted a REQUEST phase backup record into `backup:system` and another record to hold the exclusive lock.
2. Ran `backupTablesInCluster` against the cluster, which triggered repair.
3. Before the fix, repairing threw `IllegalArgumentException`. After the fix, the repair completed cleanly and released the exclusive lock.

Added a unit test to `hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRepair.java`
* Simulates failure at request stage
* Calls repair cleanup method with no `hbase.rootdir` set, validates that call doesn't throw
* Asserts that no backup exists in running state after repair
* To test locally, run `mvn17 -pl hbase-backup -P hadoop-3.0,runLargeTests -Dtest=TestBackupRepair#testRepairDoesNotThrowWhenHbaseRootDirAbsentAndPhaseIsRequest test`