### PR TITLE
[Not yet upstream] Serial replication can get stuck on empty ranges

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/SerialReplicationChecker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/SerialReplicationChecker.java
@@ -202,6 +202,13 @@ class SerialReplicationChecker {
     // start from 1. Here we choose the latter one.
     if (index < 0) {
       index = -index - 1;
+    } else if (index > 0 && barriers[index] - barriers[index - 1] == 1) {
+      // The range [barriers[index-1], barriers[index]) is exactly one seqId wide, containing only
+      // the openSeqNum which is never a real WAL entry (mvcc.advanceTo sets the base, mvcc.begin
+      // increments before the first write). This range is guaranteed empty, so don't increment —
+      // check isRangeFinished against the range before the empty one.
+      LOG.debug("{} matches barrier {} with gap-1 empty range, checking prior range", entry,
+        barriers[index]);
     } else {
       index++;
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSerialReplicationMultipleRSCrashes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSerialReplicationMultipleRSCrashes.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.replication;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.ReplicationTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.JVMClusterUtil.RegionServerThread;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Regression tests for HBASE-29499: serial replication stuck when a WAL entry's seqId exactly
+ * matches a replication barrier value.
+ * <p>
+ * When an RS is SIGKILL'ed and the region reopens on a new RS, a REGION_OPEN marker is written to
+ * the WAL with a seqId close to the new barrier value. If the RS is killed again, the new barrier
+ * can exactly match the REGION_OPEN marker's seqId from the previous incarnation. This causes
+ * {@code SerialReplicationChecker.canPush()} to check the wrong barrier endpoint, permanently
+ * blocking replication for the affected region.
+ * <p>
+ * The blocked entry then causes head-of-line blocking: all subsequent entries for that region are
+ * also blocked because their "previous range" can never be marked as finished.
+ */
+@Category({ ReplicationTests.class, LargeTests.class })
+public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTestBase {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestSerialReplicationMultipleRSCrashes.class);
+
+  @Before
+  public void setUp() throws Exception {
+    setupWALWriter();
+    addPeer(false);
+    while (UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().size() < 3) {
+      UTIL.getMiniHBaseCluster().startRegionServer();
+    }
+  }
+
+  /**
+   * Two consecutive RS crashes with data writes between them. After two crashes, the WAL reader
+   * must process entries from the old RS's WAL (via RS_CLAIM_REPLICATION_QUEUE) including
+   * REGION_OPEN markers whose seqIds can match barrier values. Replication must complete for all
+   * entries.
+   */
+  @Test
+  public void testTwoConsecutiveRSCrashes() throws Exception {
+    TableName tableName = createTable();
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 0; i < 100; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    abortRSHostingRegion(tableName);
+    UTIL.waitTableAvailable(tableName);
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 100; i < 200; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    abortRSHostingRegion(tableName);
+    UTIL.waitTableAvailable(tableName);
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 200; i < 300; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    enablePeerAndWaitUntilReplicationDone(300);
+    checkOrder(300);
+  }
+
+  /**
+   * Two consecutive RS crashes with NO data writes between them. This closely mimics the scenario
+   * from the HBASE-29499 report where the only WAL entries between the first and second crash are
+   * internal markers (REGION_OPEN, COMPACTION). When the second crash happens, the new barrier
+   * value is likely to match the REGION_OPEN marker's seqId from the first restart, because no user
+   * writes advanced the region's sequence counter beyond the open marker.
+   */
+  @Test
+  public void testTwoConsecutiveRSCrashesNoWritesBetween() throws Exception {
+    TableName tableName = createTable();
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 0; i < 100; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    abortRSHostingRegion(tableName);
+    UTIL.waitTableAvailable(tableName);
+
+    abortRSHostingRegion(tableName);
+    UTIL.waitTableAvailable(tableName);
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 100; i < 200; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    enablePeerAndWaitUntilReplicationDone(200);
+    checkOrder(200);
+  }
+
+  /**
+   * Three consecutive RS crashes to increase the number of barriers and the probability that a WAL
+   * entry's seqId matches one of them. After three crashes, the replication system must claim and
+   * process queues from two dead RS incarnations plus the current RS's own queue.
+   */
+  @Test
+  public void testThreeConsecutiveRSCrashes() throws Exception {
+    TableName tableName = createTable();
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 0; i < 50; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    abortRSHostingRegion(tableName);
+    UTIL.waitTableAvailable(tableName);
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 50; i < 100; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    abortRSHostingRegion(tableName);
+    UTIL.waitTableAvailable(tableName);
+
+    UTIL.getMiniHBaseCluster().startRegionServer();
+    UTIL.waitFor(30000, () -> UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().size() >= 2);
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 100; i < 150; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    abortRSHostingRegion(tableName);
+    UTIL.waitTableAvailable(tableName);
+
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 150; i < 200; i++) {
+        table.put(new Put(Bytes.toBytes(i)).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    enablePeerAndWaitUntilReplicationDone(200);
+    checkOrder(200);
+  }
+
+  private void abortRSHostingRegion(TableName tableName) throws Exception {
+    RegionServerThread rsThread = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
+      .filter(t -> !t.getRegionServer().getRegions(tableName).isEmpty()).findFirst()
+      .orElseThrow(() -> new RuntimeException("No live RS hosting " + tableName));
+    rsThread.getRegionServer().abort("crash for HBASE-29499 test");
+    rsThread.join();
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSerialReplicationMultipleRSCrashes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSerialReplicationMultipleRSCrashes.java
@@ -206,11 +206,11 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
       }
     }
 
-    abortRSHostingRegion(tableName, regionA);
+    abortRSHostingRegion(regionA);
     UTIL.waitFor(30000, () -> UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
       .anyMatch(t -> t.getRegionServer().getRegion(regionA.getEncodedName()) != null));
 
-    abortRSHostingRegion(tableName, regionA);
+    abortRSHostingRegion(regionA);
     UTIL.waitFor(30000, () -> UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
       .anyMatch(t -> t.getRegionServer().getRegion(regionA.getEncodedName()) != null));
 
@@ -246,7 +246,7 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
         long seqId = entry.getKey().getSequenceId();
         Long prev = lastSeqIdByRegion.get(region);
         assertTrue(
-          "Sequence id go backwards for region " + region + " from " + prev + " to " + seqId,
+          "Sequence id goes backwards for region " + region + " from " + prev + " to " + seqId,
           prev == null || seqId >= prev);
         lastSeqIdByRegion.put(region, seqId);
         count++;
@@ -255,7 +255,7 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
     }
   }
 
-  private void abortRSHostingRegion(TableName tableName, RegionInfo region) throws Exception {
+  private void abortRSHostingRegion(RegionInfo region) throws Exception {
     RegionServerThread rsThread = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
       .filter(t -> t.getRegionServer().getRegion(region.getEncodedName()) != null).findFirst()
       .orElseThrow(() -> new RuntimeException("No live RS hosting " + region.getEncodedName()));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSerialReplicationMultipleRSCrashes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSerialReplicationMultipleRSCrashes.java
@@ -45,17 +45,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**
- * Regression tests for HBASE-29499: serial replication stuck when a WAL entry's seqId exactly
- * matches a replication barrier value.
- * <p>
- * When an RS is SIGKILL'ed and the region reopens on a new RS, a REGION_OPEN marker is written to
- * the WAL with a seqId close to the new barrier value. If the RS is killed again, the new barrier
- * can exactly match the REGION_OPEN marker's seqId from the previous incarnation. This causes
- * {@code SerialReplicationChecker.canPush()} to check the wrong barrier endpoint, permanently
- * blocking replication for the affected region.
- * <p>
- * The blocked entry then causes head-of-line blocking: all subsequent entries for that region are
- * also blocked because their "previous range" can never be marked as finished.
+ * Tests that serial replication completes after consecutive RS crashes, including when a region is
+ * moved onto an RS whose WAL reader is stuck.
  */
 @Category({ ReplicationTests.class, LargeTests.class })
 public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTestBase {
@@ -73,12 +64,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
     }
   }
 
-  /**
-   * Two consecutive RS crashes with data writes between them. After two crashes, the WAL reader
-   * must process entries from the old RS's WAL (via RS_CLAIM_REPLICATION_QUEUE) including
-   * REGION_OPEN markers whose seqIds can match barrier values. Replication must complete for all
-   * entries.
-   */
   @Test
   public void testTwoConsecutiveRSCrashes() throws Exception {
     TableName tableName = createTable();
@@ -111,13 +96,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
     checkOrder(300);
   }
 
-  /**
-   * Two consecutive RS crashes with NO data writes between them. This closely mimics the scenario
-   * from the HBASE-29499 report where the only WAL entries between the first and second crash are
-   * internal markers (REGION_OPEN, COMPACTION). When the second crash happens, the new barrier
-   * value is likely to match the REGION_OPEN marker's seqId from the first restart, because no user
-   * writes advanced the region's sequence counter beyond the open marker.
-   */
   @Test
   public void testTwoConsecutiveRSCrashesNoWritesBetween() throws Exception {
     TableName tableName = createTable();
@@ -144,11 +122,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
     checkOrder(200);
   }
 
-  /**
-   * Three consecutive RS crashes to increase the number of barriers and the probability that a WAL
-   * entry's seqId matches one of them. After three crashes, the replication system must claim and
-   * process queues from two dead RS incarnations plus the current RS's own queue.
-   */
   @Test
   public void testThreeConsecutiveRSCrashes() throws Exception {
     TableName tableName = createTable();
@@ -193,21 +166,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
     checkOrder(200);
   }
 
-  /**
-   * Head-of-line blocking: Region A's stuck entry in the WAL reader prevents Region B (on the same
-   * RS) from replicating. This reproduces the incident where moving a healthy region onto a stuck
-   * RS caused the healthy region's replication to also stall.
-   * <ol>
-   * <li>Create table with 2 regions (split at row "m")</li>
-   * <li>Write data to Region A (rows starting with "a")</li>
-   * <li>Crash Region A's RS twice with no writes between → gap-1 bug on Region A</li>
-   * <li>Move Region B onto the same RS as Region A</li>
-   * <li>Write data to Region B (rows starting with "z") — these entries go into the same WAL as
-   * Region A's stuck REGION_OPEN marker</li>
-   * <li>Enable peer — Region B's entries are head-of-line blocked behind Region A's stuck
-   * entry</li>
-   * </ol>
-   */
   @Test
   public void testRegionMovedOntoStuckRSIsAlsoStuck() throws Exception {
     TableName tableName = TableName.valueOf(name.getMethodName());
@@ -234,7 +192,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
       .map(RegionServerThread::getRegionServer)
       .filter(rs -> rs.getRegion(regionB.getEncodedName()) != null).findFirst().get();
 
-    // Ensure regions are on different RSes so Region B is not affected by the crashes
     if (rsForA.getServerName().equals(rsForB.getServerName())) {
       HRegionServer otherRS = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
         .map(RegionServerThread::getRegionServer)
@@ -242,7 +199,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
       moveRegion(regionB, otherRS);
     }
 
-    // Write data to Region A
     try (Table table = UTIL.getConnection().getTable(tableName)) {
       for (int i = 0; i < 100; i++) {
         table.put(
@@ -250,7 +206,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
       }
     }
 
-    // Crash Region A's RS twice with no writes between → gap-1 bug
     abortRSHostingRegion(tableName, regionA);
     UTIL.waitFor(30000, () -> UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
       .anyMatch(t -> t.getRegionServer().getRegion(regionA.getEncodedName()) != null));
@@ -259,7 +214,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
     UTIL.waitFor(30000, () -> UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
       .anyMatch(t -> t.getRegionServer().getRegion(regionA.getEncodedName()) != null));
 
-    // Find the RS now hosting Region A and move Region B onto it
     HRegionServer stuckRS = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
       .map(RegionServerThread::getRegionServer)
       .filter(rs -> rs.getRegion(regionA.getEncodedName()) != null).findFirst().get();
@@ -267,7 +221,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
       moveRegion(regionB, stuckRS);
     }
 
-    // Write data to Region B — these entries land in the same WAL as Region A's stuck entry
     try (Table table = UTIL.getConnection().getTable(tableName)) {
       for (int i = 0; i < 100; i++) {
         table.put(
@@ -275,8 +228,6 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
       }
     }
 
-    // With the bug, Region A's stuck entry blocks the WAL reader, so Region B's
-    // entries are head-of-line blocked and never replicate.
     enablePeerAndWaitUntilReplicationDone(200);
     checkOrderPerRegion(200);
   }
@@ -308,7 +259,7 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
     RegionServerThread rsThread = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
       .filter(t -> t.getRegionServer().getRegion(region.getEncodedName()) != null).findFirst()
       .orElseThrow(() -> new RuntimeException("No live RS hosting " + region.getEncodedName()));
-    rsThread.getRegionServer().abort("crash for head-of-line blocking test");
+    rsThread.getRegionServer().abort("for testing");
     rsThread.join();
   }
 
@@ -316,7 +267,7 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
     RegionServerThread rsThread = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
       .filter(t -> !t.getRegionServer().getRegions(tableName).isEmpty()).findFirst()
       .orElseThrow(() -> new RuntimeException("No live RS hosting " + tableName));
-    rsThread.getRegionServer().abort("crash for HBASE-29499 test");
+    rsThread.getRegionServer().abort("for testing");
     rsThread.join();
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSerialReplicationMultipleRSCrashes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSerialReplicationMultipleRSCrashes.java
@@ -17,14 +17,28 @@
  */
 package org.apache.hadoop.hbase.replication;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.JVMClusterUtil.RegionServerThread;
+import org.apache.hadoop.hbase.wal.NoEOFWALStreamReader;
+import org.apache.hadoop.hbase.wal.WAL.Entry;
+import org.apache.hadoop.hbase.wal.WALStreamReader;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -177,6 +191,125 @@ public class TestSerialReplicationMultipleRSCrashes extends SerialReplicationTes
 
     enablePeerAndWaitUntilReplicationDone(200);
     checkOrder(200);
+  }
+
+  /**
+   * Head-of-line blocking: Region A's stuck entry in the WAL reader prevents Region B (on the same
+   * RS) from replicating. This reproduces the incident where moving a healthy region onto a stuck
+   * RS caused the healthy region's replication to also stall.
+   * <ol>
+   * <li>Create table with 2 regions (split at row "m")</li>
+   * <li>Write data to Region A (rows starting with "a")</li>
+   * <li>Crash Region A's RS twice with no writes between → gap-1 bug on Region A</li>
+   * <li>Move Region B onto the same RS as Region A</li>
+   * <li>Write data to Region B (rows starting with "z") — these entries go into the same WAL as
+   * Region A's stuck REGION_OPEN marker</li>
+   * <li>Enable peer — Region B's entries are head-of-line blocked behind Region A's stuck
+   * entry</li>
+   * </ol>
+   */
+  @Test
+  public void testRegionMovedOntoStuckRSIsAlsoStuck() throws Exception {
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    byte[] splitKey = Bytes.toBytes("m");
+    UTIL.getAdmin().createTable(
+      TableDescriptorBuilder.newBuilder(tableName)
+        .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(CF)
+          .setScope(HConstants.REPLICATION_SCOPE_GLOBAL).build())
+        .build(),
+      new byte[][] { splitKey });
+    UTIL.waitTableAvailable(tableName);
+
+    RegionInfo regionA =
+      UTIL.getConnection().getRegionLocator(tableName).getAllRegionLocations().stream()
+        .filter(loc -> loc.getRegion().getStartKey().length == 0).findFirst().get().getRegion();
+    RegionInfo regionB =
+      UTIL.getConnection().getRegionLocator(tableName).getAllRegionLocations().stream()
+        .filter(loc -> loc.getRegion().getStartKey().length > 0).findFirst().get().getRegion();
+
+    HRegionServer rsForA = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
+      .map(RegionServerThread::getRegionServer)
+      .filter(rs -> rs.getRegion(regionA.getEncodedName()) != null).findFirst().get();
+    HRegionServer rsForB = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
+      .map(RegionServerThread::getRegionServer)
+      .filter(rs -> rs.getRegion(regionB.getEncodedName()) != null).findFirst().get();
+
+    // Ensure regions are on different RSes so Region B is not affected by the crashes
+    if (rsForA.getServerName().equals(rsForB.getServerName())) {
+      HRegionServer otherRS = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
+        .map(RegionServerThread::getRegionServer)
+        .filter(rs -> !rs.getServerName().equals(rsForA.getServerName())).findFirst().get();
+      moveRegion(regionB, otherRS);
+    }
+
+    // Write data to Region A
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 0; i < 100; i++) {
+        table.put(
+          new Put(Bytes.toBytes(String.format("a%04d", i))).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    // Crash Region A's RS twice with no writes between → gap-1 bug
+    abortRSHostingRegion(tableName, regionA);
+    UTIL.waitFor(30000, () -> UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
+      .anyMatch(t -> t.getRegionServer().getRegion(regionA.getEncodedName()) != null));
+
+    abortRSHostingRegion(tableName, regionA);
+    UTIL.waitFor(30000, () -> UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
+      .anyMatch(t -> t.getRegionServer().getRegion(regionA.getEncodedName()) != null));
+
+    // Find the RS now hosting Region A and move Region B onto it
+    HRegionServer stuckRS = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
+      .map(RegionServerThread::getRegionServer)
+      .filter(rs -> rs.getRegion(regionA.getEncodedName()) != null).findFirst().get();
+    if (stuckRS.getRegion(regionB.getEncodedName()) == null) {
+      moveRegion(regionB, stuckRS);
+    }
+
+    // Write data to Region B — these entries land in the same WAL as Region A's stuck entry
+    try (Table table = UTIL.getConnection().getTable(tableName)) {
+      for (int i = 0; i < 100; i++) {
+        table.put(
+          new Put(Bytes.toBytes(String.format("z%04d", i))).addColumn(CF, CQ, Bytes.toBytes(i)));
+      }
+    }
+
+    // With the bug, Region A's stuck entry blocks the WAL reader, so Region B's
+    // entries are head-of-line blocked and never replicate.
+    enablePeerAndWaitUntilReplicationDone(200);
+    checkOrderPerRegion(200);
+  }
+
+  private void checkOrderPerRegion(int expectedEntries) throws IOException {
+    try (WALStreamReader reader =
+      NoEOFWALStreamReader.create(UTIL.getTestFileSystem(), logPath, UTIL.getConfiguration())) {
+      Map<String, Long> lastSeqIdByRegion = new HashMap<>();
+      int count = 0;
+      for (Entry entry;;) {
+        entry = reader.next();
+        if (entry == null) {
+          break;
+        }
+        String region = Bytes.toString(entry.getKey().getEncodedRegionName());
+        long seqId = entry.getKey().getSequenceId();
+        Long prev = lastSeqIdByRegion.get(region);
+        assertTrue(
+          "Sequence id go backwards for region " + region + " from " + prev + " to " + seqId,
+          prev == null || seqId >= prev);
+        lastSeqIdByRegion.put(region, seqId);
+        count++;
+      }
+      assertEquals(expectedEntries, count);
+    }
+  }
+
+  private void abortRSHostingRegion(TableName tableName, RegionInfo region) throws Exception {
+    RegionServerThread rsThread = UTIL.getMiniHBaseCluster().getLiveRegionServerThreads().stream()
+      .filter(t -> t.getRegionServer().getRegion(region.getEncodedName()) != null).findFirst()
+      .orElseThrow(() -> new RuntimeException("No live RS hosting " + region.getEncodedName()));
+    rsThread.getRegionServer().abort("crash for head-of-line blocking test");
+    rsThread.join();
   }
 
   private void abortRSHostingRegion(TableName tableName) throws Exception {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestSerialReplicationChecker.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestSerialReplicationChecker.java
@@ -303,22 +303,14 @@ public class TestSerialReplicationChecker {
 
   @Test
   public void testCanPushEqualsToBarrierWithGapOne() throws IOException, ReplicationException {
-    // When consecutive barriers differ by 1, the range between them is empty (contains only
-    // the openSeqNum which has no WAL entry). An entry whose seqId matches the later barrier
-    // must not get stuck on the empty range.
     RegionInfo region = RegionInfoBuilder.newBuilder(tableName).build();
     Cell cell = createCell(region);
 
-    // Gap-1 at the end: barriers [10, 100, 101], range [100, 101) is empty
     addStateAndBarrier(region, RegionState.State.OPEN, 10, 100, 101);
-    // Prior range [10, 100) not finished yet — should block
     assertFalse(checker.canPush(createEntry(region, 101), cell));
-    // Finish the prior range [10, 100)
     updatePushedSeqId(region, 99);
-    // Now the empty range [100, 101) should be skipped — should pass
     assertTrue(checker.canPush(createEntry(region, 101), cell));
 
-    // Exact scenario from the Mamba CDC investigation
     addStateAndBarrier(region, RegionState.State.OPEN, 9, 17, 25, 28, 31, 34, 38, 39);
     updatePushedSeqId(region, 37);
     assertTrue(checker.canPush(createEntry(region, 39), cell));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestSerialReplicationChecker.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestSerialReplicationChecker.java
@@ -300,4 +300,27 @@ public class TestSerialReplicationChecker {
     updatePushedSeqId(region, 99);
     assertTrue(checker.canPush(createEntry(region, 100), cell));
   }
+
+  @Test
+  public void testCanPushEqualsToBarrierWithGapOne() throws IOException, ReplicationException {
+    // When consecutive barriers differ by 1, the range between them is empty (contains only
+    // the openSeqNum which has no WAL entry). An entry whose seqId matches the later barrier
+    // must not get stuck on the empty range.
+    RegionInfo region = RegionInfoBuilder.newBuilder(tableName).build();
+    Cell cell = createCell(region);
+
+    // Gap-1 at the end: barriers [10, 100, 101], range [100, 101) is empty
+    addStateAndBarrier(region, RegionState.State.OPEN, 10, 100, 101);
+    // Prior range [10, 100) not finished yet — should block
+    assertFalse(checker.canPush(createEntry(region, 101), cell));
+    // Finish the prior range [10, 100)
+    updatePushedSeqId(region, 99);
+    // Now the empty range [100, 101) should be skipped — should pass
+    assertTrue(checker.canPush(createEntry(region, 101), cell));
+
+    // Exact scenario from the Mamba CDC investigation
+    addStateAndBarrier(region, RegionState.State.OPEN, 9, 17, 25, 28, 31, 34, 38, 39);
+    updatePushedSeqId(region, 37);
+    assertTrue(checker.canPush(createEntry(region, 39), cell));
+  }
 }


### PR DESCRIPTION
This is a long PR description, but the summary is that serial replication can get stuck if a server crashes twice without having edits in between. Basically, if the situation is:
- Write edits
- Server crashes
- Server crashes (no new edits)
- Write edits <-- these will be stuck forever

## Fix serial replication stuck after consecutive RegionServer crashes

### Problem

Serial replication can get permanently stuck after an RS is restarted (gracefully or via SIGKILL) multiple times without user writes between restarts. Once stuck, the affected RS's WAL reader blocks indefinitely in `waitUntilCanPush()`, causing head-of-line blocking for all regions sharing that WAL — including unrelated regions moved onto the stuck RS after the fact.

### Mamba CDC outage

On an hbase cluster, a CDC peer was created on Jul 13 while a rolling Hadoop datanode upgrade was in progress. The upgrade uses a drain/return pattern: displacing all ~95 regions from each RS to temporary RSs, rolling WALs, stopping the RS, restarting, then returning regions. Each upgrade creates two barriers per region (one on drain, one on return).

Over Jul 14-16, the upgrade job restarted 33 RSs. Each drain/return cycle created intermediate barrier ranges with no user writes between them. WAL reader threads became stuck in `SerialReplicationChecker.waitUntilCanPush()` on REGION_OPEN entries for these intermediate ranges, with the log message:

```
Previous range for <hubspot table>/.../862704391 has not been finished yet, give up
```

Thread dumps showed WAL readers in `TIMED_WAITING` with waited counts of 65K-104K (looping for days). The stuck entries blocked all subsequent WAL entries via head-of-line blocking, cascading from 4 stuck RSs on Jul 14 to all 33 RSs by Jul 15 22:00. The only resolution was deleting and re-creating the CDC peer.

Example from a host:
```
barriers=[862629162, 862681720, 862703835, 862704390, 862758946, 862759989, 862760093]
```
Stuck range `[862703835, 862704390)` = 555 seqIds spanning 13 minutes (Jul 15 10:59-11:12), created by a drain/return bounce during the upgrade.

### Root cause

When an RS restarts and opens a region, a new replication barrier (`openSeqNum`) is written to `hbase:meta`, and a `REGION_OPEN` marker is appended to the WAL. The marker's seqId is always `openSeqNum + 1` because `mvcc.advanceTo(openSeqNum)` sets the base, then `mvcc.begin()` increments before the write.

If the RS restarts again before any user data is written, the next RS computes its `openSeqNum` from recovery, which lands at `previousOpenSeqNum + 1`. This creates two consecutive barriers that differ by exactly 1.

The range between these barriers (e.g., `[38, 39)`) contains only seqId 38, the `openSeqNum` itself. No WAL entry is ever written at the `openSeqNum` — it's set via `mvcc.advanceTo()`, not `mvcc.begin()` — so this range is empty.

Meanwhile, the `REGION_OPEN` marker from the previous restart has seqId `openSeqNum + 1`, which exactly matches the new barrier.

In `SerialReplicationChecker.canPush()`, `Arrays.binarySearch(barriers, seqId)` finds this exact match. The code does `index++` to convert from 0-based to 1-based range indexing, causing `isRangeFinished(barriers[index-1])` to check the empty range:

```
isRangeFinished(39) → pushedSeqId >= 38
```

No WAL entry at seqId 38 exists, so `pushedSeqId` never reaches 38. The check fails permanently, and `waitUntilCanPush` spins indefinitely.

This blocks the WAL reader thread entirely. Since `SerialReplicationSourceWALReader` is single-threaded and processes entries sequentially, any entries after the stuck one — including entries for unrelated regions — are head-of-line blocked.

See [HBASE-29499](issues.apache.org/jira/browse/HBASE-29499) for further details and independent reproduction by the Apache HBase community.

### Fix

In `SerialReplicationChecker.canPush()`: when `seqId` exactly matches a barrier at position `index > 0` and `barriers[index] - barriers[index-1] == 1`, don't increment the index. This makes `isRangeFinished` check the range before the empty gap-1 range instead of the empty range itself.

The `gap == 1` condition precisely identifies empty ranges:
- The only seqId in `[X, X+1)` is `X`, which is the `openSeqNum`
- `openSeqNum` never has a WAL entry (`mvcc.advanceTo` doesn't write; `mvcc.begin` increments past it)
- A data entry's seqId can never equal a later barrier because `barrier = maxPreviousSeqId + 1` and the data entry is one of those previous seqIds, so `barrier > dataSeqId`

For `gap > 1`, the range contains at least the `REGION_OPEN` marker, which gets processed by the WAL reader and advances `pushedSeqId` — so the normal `index++` path works correctly.

### Why skipping the empty range is safe

The fix skips the `isRangeFinished` check for gap-1 ranges. This cannot cause out-of-order replication or dropped messages because:

**The range is provably empty.** A gap-1 range `[X, X+1)` contains only seqId `X`, which is the `openSeqNum`. The `openSeqNum` is set via `mvcc.advanceTo(X)` — this advances the MVCC write point without calling `mvcc.begin()`, so no WAL entry is written at that seqId. The first actual WAL entry is the `REGION_OPEN` marker at `X+1` (from `mvcc.begin()` which increments the write point). Since the range contains zero WAL entries, there is nothing to replicate and nothing to skip.

**Prior data is still checked.** The fix doesn't remove the ordering check — it shifts it one range back. With the un-incremented index, `isRangeFinished(barriers[index-1])` verifies that all data from the range *before* the empty range has been fully replicated. If that prior range still has unreplicated entries, `canPush` returns false and the WAL reader waits, preserving serial ordering.

**Entries within the same WAL are ordered.** The stuck entry (the `REGION_OPEN` marker at `seqId == barrier`) and any preceding data entries from the same RS incarnation are in the same WAL file. The `SerialReplicationSourceWALReader` processes WAL entries sequentially, so by the time it reaches the `REGION_OPEN` marker, all earlier entries from that WAL have already been read into the batch. They are shipped to the peer in order before the marker's seqId is recorded.

**Cross-WAL ordering is enforced by the prior range check.** Data from earlier RS incarnations lives in different WALs, processed by separate claimed-queue readers. The `isRangeFinished` check that the fix preserves (against the range before the empty one) ensures that all data from those earlier incarnations has been replicated before the boundary entry is allowed through. The empty gap-1 range sits between the completed prior data and the current entry — skipping its check doesn't change the fact that the prior data must finish first.