### PR TITLE
HubSpot Backport: HBASE-30299 Filter secondary replicas from region normalizer (will be in 2.6.6)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
@@ -649,6 +649,8 @@ class SimpleRegionNormalizer implements RegionNormalizer, ConfigurationObserver 
       regionStates =
         SimpleRegionNormalizer.this.masterServices.getAssignmentManager().getRegionStates();
       tableRegions = regionStates.getRegionsOfTable(tableName);
+
+      tableRegions.removeIf(r -> r.getReplicaId() != RegionInfo.DEFAULT_REPLICA_ID);
       // The list of regionInfo from getRegionsOfTable() is ordered by regionName.
       // regionName does not necessary guarantee the order by STARTKEY (let's say 'aa1', 'aa1!',
       // in order by regionName, it will be 'aa1!' followed by 'aa1').

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
@@ -760,6 +760,7 @@ public class TestSimpleRegionNormalizer {
 
   @Test
   public void testIgnoresSecondaryReplicasForMergeAndSplitPlanning() {
+    final TableName tableName = name.getTableName();
     conf.setBoolean(SPLIT_ENABLED_KEY, true);
     conf.setBoolean(MERGE_ENABLED_KEY, true);
     conf.setInt(MERGE_MIN_REGION_COUNT_KEY, 1);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
@@ -757,4 +757,27 @@ public class TestSimpleRegionNormalizer {
     }
     return ret;
   }
+
+  @Test
+  public void testIgnoresSecondaryReplicasForMergeAndSplitPlanning() {
+    conf.setBoolean(SPLIT_ENABLED_KEY, true);
+    conf.setBoolean(MERGE_ENABLED_KEY, true);
+    conf.setInt(MERGE_MIN_REGION_COUNT_KEY, 1);
+    conf.setInt(MERGE_MIN_REGION_SIZE_MB_KEY, 0);
+
+    final List<RegionInfo> primaryRegions = createRegionInfos(tableName, 5);
+    final List<RegionInfo> allRegions = new ArrayList<>(primaryRegions);
+    for (RegionInfo primary : primaryRegions) {
+      allRegions.add(RegionInfoBuilder.newBuilder(tableName).setStartKey(primary.getStartKey())
+        .setEndKey(primary.getEndKey()).setRegionId(primary.getRegionId()).setReplicaId(1).build());
+    }
+
+    final Map<byte[], Integer> regionSizes = createRegionSizesMap(primaryRegions, 15, 5, 5, 15, 16);
+    setupMocksForNormalizer(regionSizes, allRegions);
+
+    final List<NormalizationPlan> plans = normalizer.computePlansForTable(tableDescriptor);
+    assertThat(plans, hasSize(1));
+    assertThat(plans, contains(new MergeNormalizationPlan.Builder()
+      .addTarget(primaryRegions.get(1), 5).addTarget(primaryRegions.get(2), 5).build()));
+  }
 }


### PR DESCRIPTION
## Summary

Backport of apache/hbase#cd4fce2 to `hubspot-2.6`.

Fixes a bug where `SimpleRegionNormalizer` included secondary replica regions in merge/split planning. Adds a filter in `NormalizeContext` to remove non-default replicas so only primary regions are considered for normalization.

## Source

- Upstream commit: https://github.com/apache/hbase/commit/cd4fce203fd3c736d2d904205d1b3e4243200a7c
- Branch: `branch-2.6`

-added tableName var to follow Hubspot conventions 

## Changes

- `SimpleRegionNormalizer.java`: filter out non-default replica regions from `tableRegions`
- `TestSimpleRegionNormalizer.java`: add `testIgnoresSecondaryReplicasForMergeAndSplitPlanning`

