### PR TITLE
Add missingFileExceptions counter to detect swallowed HDFS replica errors

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSource.java
@@ -47,6 +47,7 @@ public interface ExceptionTrackingSource extends BaseSource {
   String EXCEPTIONS_CALL_TIMED_OUT = "exceptions.callTimedOut";
   String EXCEPTIONS_REQUEST_TOO_BIG = "exceptions.requestTooBig";
   String OTHER_EXCEPTIONS = "exceptions.otherExceptions";
+  String EXCEPTIONS_MISSING_FILE_NAME = "exceptions.missingFileExceptions";
 
   void exception();
 
@@ -82,4 +83,6 @@ public interface ExceptionTrackingSource extends BaseSource {
   void requestTooBigException();
 
   void otherExceptions();
+
+  void missingFileException();
 }

--- a/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSourceImpl.java
+++ b/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSourceImpl.java
@@ -41,6 +41,7 @@ public class ExceptionTrackingSourceImpl extends BaseSourceImpl implements Excep
   protected MutableFastCounter exceptionsCallTimedOut;
   protected MutableFastCounter exceptionRequestTooBig;
   protected MutableFastCounter otherExceptions;
+  protected MutableFastCounter exceptionsMissingFile;
 
   public ExceptionTrackingSourceImpl(String metricsName, String metricsDescription,
     String metricsContext, String metricsJmxContext) {
@@ -81,6 +82,8 @@ public class ExceptionTrackingSourceImpl extends BaseSourceImpl implements Excep
       this.getMetricsRegistry().newCounter(EXCEPTIONS_REQUEST_TOO_BIG, EXCEPTIONS_TYPE_DESC, 0L);
     this.otherExceptions =
       this.getMetricsRegistry().newCounter(OTHER_EXCEPTIONS, EXCEPTIONS_TYPE_DESC, 0L);
+    this.exceptionsMissingFile =
+      this.getMetricsRegistry().newCounter(EXCEPTIONS_MISSING_FILE_NAME, EXCEPTIONS_TYPE_DESC, 0L);
   }
 
   @Override
@@ -161,5 +164,10 @@ public class ExceptionTrackingSourceImpl extends BaseSourceImpl implements Excep
   @Override
   public void otherExceptions() {
     otherExceptions.incr();
+  }
+
+  @Override
+  public void missingFileException() {
+    exceptionsMissingFile.incr();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
@@ -155,6 +155,10 @@ public class MetricsHBaseServer {
     }
   }
 
+  public void missingFileException() {
+    source.missingFileException();
+  }
+
   void callTimedOut() {
     source.callTimedOut();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -1165,6 +1165,12 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
       newHeap = newKVHeap(newCurrentScanners, comparator);
     } catch (Exception e) {
       LOG.warn("failed to switch to stream read", e);
+      if (isMissingFileException(e)) {
+        RegionServerServices rss = store.getHRegion().getRegionServerServices();
+        if (rss != null && rss.getRpcServer() != null) {
+          rss.getRpcServer().getMetrics().missingFileException();
+        }
+      }
       if (fileScanners != null) {
         fileScanners.forEach(KeyValueScanner::close);
       }
@@ -1178,6 +1184,17 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     if (hasSwitchedToStreamRead != null) {
       hasSwitchedToStreamRead.set(true);
     }
+  }
+
+  private static boolean isMissingFileException(Exception e) {
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      String msg = t.getMessage();
+      if (msg != null
+        && (msg.contains("ReplicaNotFoundException") || msg.contains("StoreFileNotFoundException"))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   protected final boolean checkFlushed() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -1189,8 +1189,10 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
   private static boolean isMissingFileException(Exception e) {
     for (Throwable t = e; t != null; t = t.getCause()) {
       String msg = t.getMessage();
-      if (msg != null
-        && (msg.contains("ReplicaNotFoundException") || msg.contains("StoreFileNotFoundException"))) {
+      if (
+        msg != null && (msg.contains("ReplicaNotFoundException")
+          || msg.contains("StoreFileNotFoundException"))
+      ) {
         return true;
       }
     }


### PR DESCRIPTION
## Description

`ReplicaNotFoundException` and `StoreFileNotFoundException` are caught inside the broad `Exception` handler in `StoreScanner#trySwitchToStreamRead` and only surface in RS logs at WARN level — they never propagate to the HBase client and are completely invisible to existing alerting. During a stream-read mode switch the RS seeks newly-opened HFile scanners back to their last position; an HDFS block-read failure (e.g. a missing replica) throws here, the switch is silently abandoned, and the scan continues on the old pread scanners. No data is lost, but the event is unobservable.

This change adds a `missingFileExceptions` counter to the existing IPC exception metrics infrastructure. Because `ReplicaNotFoundException` is an HDFS server-side class not on the HBase classpath, detection walks the cause-chain checking message strings. The collectd plugin already scrapes all `exceptions.*` attributes from the RegionServer IPC JMX bean, so the new counter lands in VictoriaMetrics automatically as `collectd_hbase_exceptions_identified_total{type="missingFileExceptions"}` with no changes needed outside this repo.

### [Issue]()

## BRAVE

#### Backwards Compatibility

Counter is additive — new JMX attribute registered in `ExceptionTrackingSourceImpl.init()`. No existing attributes removed or renamed.

#### Rollout and Rollback Plan

No config flag needed. Counter starts at zero and increments only on the specific exception message pattern. Rollback is a revert.

#### Automated Testing

#### Verification

After deploy: query `collectd_hbase_exceptions_identified_total{type="missingFileExceptions"}` in VictoriaMetrics on saturn-hb2-a-prod and confirm the metric appears (value may be zero if no events since deploy).

#### Expect Dependencies to Fail

##### *REVIEWERS*: Please review both the code changes and the answers above, and validate that they match the expectations for BRAVE